### PR TITLE
ENH: a faster indexing algorithm

### DIFF
--- a/gpgi/lib/_indexing.py
+++ b/gpgi/lib/_indexing.py
@@ -9,31 +9,43 @@ def _index_particles(
 ):
     for ipart in range(particle_count):
         x = particle_coords[ipart, 0]
-        edges = cell_edges_x1
-        max_idx = len(cell_edges_x1) - 1
-        idx = 0
-        while idx < max_idx and edges[idx + 1] < x:
-            idx += 1
+        iL = 0
+        iR = cell_edges_x1.shape[0] - 1
+        idx = (iL + iR) // 2
+        while idx != iL:
+            if cell_edges_x1[idx] > x:
+                iR = idx
+            else:
+                iL = idx
+            idx = (iL + iR) // 2
         out[ipart, 0] = idx
 
         if ndim < 2:
             continue
 
         x = particle_coords[ipart, 1]
-        edges = cell_edges_x2
-        max_idx = len(cell_edges_x2) + 1
-        idx = 0
-        while idx < max_idx and edges[idx + 1] < x:
-            idx += 1
+        iL = 0
+        iR = cell_edges_x2.shape[0] - 1
+        idx = (iL + iR) // 2
+        while idx != iL:
+            if cell_edges_x2[idx] > x:
+                iR = idx
+            else:
+                iL = idx
+            idx = (iL + iR) // 2
         out[ipart, 1] = idx
 
         if ndim < 3:
             continue
 
         x = particle_coords[ipart, 2]
-        edges = cell_edges_x3
-        max_idx = len(cell_edges_x3) + 1
-        idx = 0
-        while idx < max_idx and edges[idx + 1] < x:
-            idx += 1
+        iL = 0
+        iR = cell_edges_x3.shape[0] - 1
+        idx = (iL + iR) // 2
+        while idx != iL:
+            if cell_edges_x3[idx] > x:
+                iR = idx
+            else:
+                iL = idx
+            idx = (iL + iR) // 2
         out[ipart, 2] = idx


### PR DESCRIPTION
replace N complexity with log2(N) (where N is the number of cells in each direction).

Indexing 100_000 particles in a 1023^3 cube is about 40x faster, even in pure Python