### PR TITLE
ENH: implement fast particle indexing for constant stepping grids

### DIFF
--- a/gpgi/__init__.py
+++ b/gpgi/__init__.py
@@ -2,4 +2,4 @@ from __future__ import annotations
 
 from .api import load
 
-__version__ = "0.1.0"
+__version__ = "0.2.dev0"

--- a/gpgi/clib/_indexing.pyx
+++ b/gpgi/clib/_indexing.pyx
@@ -6,12 +6,14 @@ cdef fused real:
     np.float64_t
     np.float32_t
 
+@cython.cdivision(True)
 @cython.boundscheck(False)
 @cython.wraparound(False)
 def _index_particles(
     np.ndarray[real, ndim=1] cell_edges_x1,
     np.ndarray[real, ndim=1] cell_edges_x2,
     np.ndarray[real, ndim=1] cell_edges_x3,
+    np.ndarray[real, ndim=1] dx,
     np.ndarray[real, ndim=2] particle_coords,
     np.ndarray[np.uint16_t, ndim=2] out,
 ):
@@ -31,43 +33,52 @@ def _index_particles(
 
     for ipart in range(particle_count):
         x = particle_coords[ipart, 0]
-        iL = 0
-        iR = cell_edges_x1.shape[0] - 1
-        idx = (iL + iR) // 2
-        while idx != iL:
-            if cell_edges_x1[idx] > x:
-                iR = idx
-            else:
-                iL = idx
+        if dx[0] > 0:
+            out[ipart, 0] = int((x - cell_edges_x1[0]) // dx[0])
+        else:
+            iL = 0
+            iR = cell_edges_x1.shape[0] - 1
             idx = (iL + iR) // 2
-        out[ipart, 0] = idx
+            while idx != iL:
+                if cell_edges_x1[idx] > x:
+                    iR = idx
+                else:
+                    iL = idx
+                idx = (iL + iR) // 2
+            out[ipart, 0] = idx
 
         if ndim < 2:
             continue
 
         x = particle_coords[ipart, 1]
-        iL = 0
-        iR = cell_edges_x2.shape[0] - 1
-        idx = (iL + iR) // 2
-        while idx != iL:
-            if cell_edges_x2[idx] > x:
-                iR = idx
-            else:
-                iL = idx
+        if dx[1] > 0:
+            out[ipart, 1] = int((x - cell_edges_x2[0]) // dx[1])
+        else:
+            iL = 0
+            iR = cell_edges_x2.shape[0] - 1
             idx = (iL + iR) // 2
-        out[ipart, 1] = idx
+            while idx != iL:
+                if cell_edges_x2[idx] > x:
+                    iR = idx
+                else:
+                    iL = idx
+                idx = (iL + iR) // 2
+            out[ipart, 1] = idx
 
         if ndim < 3:
             continue
 
         x = particle_coords[ipart, 2]
-        iL = 0
-        iR = cell_edges_x3.shape[0] - 1
-        idx = (iL + iR) // 2
-        while idx != iL:
-            if cell_edges_x3[idx] > x:
-                iR = idx
-            else:
-                iL = idx
+        if dx[2] > 0:
+            out[ipart, 2] = int((x - cell_edges_x3[0]) // dx[2])
+        else:
+            iL = 0
+            iR = cell_edges_x3.shape[0] - 1
             idx = (iL + iR) // 2
-        out[ipart, 2] = idx
+            while idx != iL:
+                if cell_edges_x3[idx] > x:
+                    iR = idx
+                else:
+                    iL = idx
+                idx = (iL + iR) // 2
+            out[ipart, 2] = idx

--- a/gpgi/lib/_indexing.py
+++ b/gpgi/lib/_indexing.py
@@ -2,6 +2,7 @@ def _index_particles(
     cell_edges_x1,
     cell_edges_x2,
     cell_edges_x3,
+    dx,
     particle_coords,
     out,
 ):
@@ -16,43 +17,52 @@ def _index_particles(
 
     for ipart in range(particle_count):
         x = particle_coords[ipart, 0]
-        iL = 0
-        iR = cell_edges_x1.shape[0] - 1
-        idx = (iL + iR) // 2
-        while idx != iL:
-            if cell_edges_x1[idx] > x:
-                iR = idx
-            else:
-                iL = idx
+        if dx[0] > 0:
+            out[ipart, 0] = int((x - cell_edges_x1[0]) // dx[0])
+        else:
+            iL = 0
+            iR = cell_edges_x1.shape[0] - 1
             idx = (iL + iR) // 2
-        out[ipart, 0] = idx
+            while idx != iL:
+                if cell_edges_x1[idx] > x:
+                    iR = idx
+                else:
+                    iL = idx
+                idx = (iL + iR) // 2
+            out[ipart, 0] = idx
 
         if ndim < 2:
             continue
 
         x = particle_coords[ipart, 1]
-        iL = 0
-        iR = cell_edges_x2.shape[0] - 1
-        idx = (iL + iR) // 2
-        while idx != iL:
-            if cell_edges_x2[idx] > x:
-                iR = idx
-            else:
-                iL = idx
+        if dx[1] > 0:
+            out[ipart, 1] = int((x - cell_edges_x2[0]) // dx[1])
+        else:
+            iL = 0
+            iR = cell_edges_x2.shape[0] - 1
             idx = (iL + iR) // 2
-        out[ipart, 1] = idx
+            while idx != iL:
+                if cell_edges_x2[idx] > x:
+                    iR = idx
+                else:
+                    iL = idx
+                idx = (iL + iR) // 2
+            out[ipart, 1] = idx
 
         if ndim < 3:
             continue
 
         x = particle_coords[ipart, 2]
-        iL = 0
-        iR = cell_edges_x3.shape[0] - 1
-        idx = (iL + iR) // 2
-        while idx != iL:
-            if cell_edges_x3[idx] > x:
-                iR = idx
-            else:
-                iL = idx
+        if dx[2] > 0:
+            out[ipart, 2] = int((x - cell_edges_x3[0]) // dx[2])
+        else:
+            iL = 0
+            iR = cell_edges_x3.shape[0] - 1
             idx = (iL + iR) // 2
-        out[ipart, 2] = idx
+            while idx != iL:
+                if cell_edges_x3[idx] > x:
+                    iR = idx
+                else:
+                    iL = idx
+                idx = (iL + iR) // 2
+            out[ipart, 2] = idx

--- a/gpgi/types.py
+++ b/gpgi/types.py
@@ -154,6 +154,12 @@ class Grid(CoordinateValidatorMixin):
         self.axes = tuple(self.coordinates.keys())
         super().__init__()
 
+        self._dx = np.full((3,), -1, dtype=self.coordinates[self.axes[0]].dtype)
+        for i, ax in enumerate(self.axes):
+            if np.diff(self.coordinates[ax]).std() < 1e-16:
+                # got a constant step in this direction, store it
+                self._dx[i] = self.coordinates[ax][1] - self.coordinates[ax][0]
+
     def _validate(self) -> None:
         self._validate_geometry()
         self._validate_coordinates()
@@ -285,6 +291,7 @@ class Dataset(ValidatorMixin):
             cell_edges_x1=cell_edges_x1,
             cell_edges_x2=cell_edges_x2,
             cell_edges_x3=cell_edges_x3,
+            dx=self.grid._dx,
             particle_coords=particle_coords,
             out=self._hci,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
 
 [project]
 name = "gpgi"
-version = "0.1.0"
+version = "0.2.dev0"
 description = "A Generic Particle+Grid Interface"
 authors = [
     { name = "C.M.T. Robert" },


### PR DESCRIPTION
fix #20

TODO:
- [x] possibly refine Cython implementation (right now it's still using Python interaction, but it's still a ~ x20 boost on my benchmark)

edit: problem (and solution) are discussed in this SO thread https://stackoverflow.com/questions/4709285/cython-float-division-pyexc-zerodivisionerror-checking
using the `@cython.cdivision(True)` decorator further speeds up fast indexing by about 3%, which is nowhere near the original optimization, but it's still very much worth the cost, so I'll include it.