### PR TITLE
ENH: add support for weight fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,12 +199,16 @@ def ones(
     same_side_ghost_layer,
     opposite_side_active_layer,
     opposite_side_ghost_layer,
+    weight_same_side_active_layer,
+    weight_same_side_ghost_layer,
+    weight_opposite_side_active_layer,
+    weight_opposite_side_ghost_layer,
     side,
     metadata,
 ):
    return 1.0
 ```
-where all first four arguments are `numpy.ndarray` objects with the same shape,
+where all first eight arguments are `numpy.ndarray` objects with the same shape (which includes ghost padding !),
 to which the return value must be broadcastable, `side` can only be either
 `"left"` or `"right"`, and `metadata` is the special `Dataset.metadata`
 attribute. Not all arguments need be used in the body of the function, but this
@@ -226,3 +230,31 @@ ds.deposit(
     }
 )
 ```
+
+Note that all first eight arguments in a boundary recipe function should
+represent an *extensive* physical quantity (as opposed to *intensive*). When
+depositing an *intensive* quantity `u`, a weight field `w` should be supplied
+(see next section), in which case, the first four arguments represent `u*w` and
+the following four represent *w*, so that *u* can still be obtained within the
+function as a ratio if needed.
+
+### Weight fields
+*new in gpgi 0.7.0*
+
+Intrisically, deposition algorithms assume that the deposited field `u`
+represents an *extensive* physical quantity (like mass or momentum).
+In order to deposit a *intentive* quantity (like velocity or temperature), one must provide an appropriate weight field `w`.
+
+Let `u'` and `w'` be the equivalent on-grid descriptions to `u` and `w`. They are obtained as
+
+```
+w'(x) = Σ w(i) c(i,x)
+u'(x) = (1/w'(x)) Σ u(i) w(i) c(i,x)
+```
+where `x` is the spatial position, `i` is a particle index, and `c(i,x)` are
+geometric coefficients associated with the deposition method.
+
+Boundary recipes may be associated to the weight field with the
+`weight_field_boundaries` argument.
+
+Call `help(ds.deposit)` for more detail.

--- a/gpgi/_boundaries.py
+++ b/gpgi/_boundaries.py
@@ -17,6 +17,10 @@ BoundaryRecipeT = Callable[
         "RealArray",
         "RealArray",
         "RealArray",
+        "RealArray",
+        "RealArray",
+        "RealArray",
+        "RealArray",
         Literal["left", "right"],
         Dict[str, Any],
     ],
@@ -41,6 +45,10 @@ class BoundaryRegistry:
             "same_side_ghost_layer",
             "opposite_side_active_layer",
             "opposite_side_ghost_layer",
+            "weight_same_side_active_layer",
+            "weight_same_side_ghost_layer",
+            "weight_opposite_side_active_layer",
+            "weight_opposite_side_ghost_layer",
             "side",
             "metadata",
         ]:
@@ -48,6 +56,8 @@ class BoundaryRegistry:
                 "Invalid boundary recipe. Expected a function with exactly 6 parameters, "
                 "named 'same_side_active_layer', 'same_side_ghost_layer', "
                 "'opposite_side_active_layer', 'opposite_side_ghost_layer', "
+                "'weight_same_side_active_layer', 'weight_same_side_ghost_layer', "
+                "'weight_opposite_side_active_layer', 'weight_opposite_side_ghost_layer', "
                 "'side', and 'metadata'"
             )
 
@@ -74,6 +84,10 @@ def open_boundary(
     same_side_ghost_layer: RealArray,
     opposite_side_active_layer: RealArray,
     opposite_side_ghost_layer: RealArray,
+    weight_same_side_active_layer: RealArray,
+    weight_same_side_ghost_layer: RealArray,
+    weight_opposite_side_active_layer: RealArray,
+    weight_opposite_side_ghost_layer: RealArray,
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> RealArray:
@@ -86,6 +100,10 @@ def wall_boundary(
     same_side_ghost_layer: RealArray,
     opposite_side_active_layer: RealArray,
     opposite_side_ghost_layer: RealArray,
+    weight_same_side_active_layer: RealArray,
+    weight_same_side_ghost_layer: RealArray,
+    weight_opposite_side_active_layer: RealArray,
+    weight_opposite_side_ghost_layer: RealArray,
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> RealArray:
@@ -97,6 +115,10 @@ def antisymmetric_boundary(
     same_side_ghost_layer: RealArray,
     opposite_side_active_layer: RealArray,
     opposite_side_ghost_layer: RealArray,
+    weight_same_side_active_layer: RealArray,
+    weight_same_side_ghost_layer: RealArray,
+    weight_opposite_side_active_layer: RealArray,
+    weight_opposite_side_ghost_layer: RealArray,
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> RealArray:
@@ -108,6 +130,10 @@ def periodic_boundary(
     same_side_ghost_layer: RealArray,
     opposite_side_active_layer: RealArray,
     opposite_side_ghost_layer: RealArray,
+    weight_same_side_active_layer: RealArray,
+    weight_same_side_ghost_layer: RealArray,
+    weight_opposite_side_active_layer: RealArray,
+    weight_opposite_side_ghost_layer: RealArray,
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> RealArray:

--- a/gpgi/lib/_deposition_methods.py
+++ b/gpgi/lib/_deposition_methods.py
@@ -9,12 +9,18 @@ def _deposit_ngp(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
-    for ipart in range(len(hci)):
-        md_idx = tuple(hci[ipart])
-        out[md_idx] += field[ipart]
+    if weight_field.size == 0:
+        for ipart in range(len(hci)):
+            md_idx = tuple(hci[ipart])
+            out[md_idx] += field[ipart]
+    else:
+        for ipart in range(len(hci)):
+            md_idx = tuple(hci[ipart])
+            out[md_idx] += field[ipart] * weight_field[ipart]
 
 
 def _deposit_cic_1D(
@@ -25,9 +31,13 @@ def _deposit_cic_1D(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
+    if weight_field.size > 0:
+        raise NotImplementedError
+
     nparticles = hci.shape[0]
 
     # weight array
@@ -58,9 +68,13 @@ def _deposit_cic_2D(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
+    if weight_field.size > 0:
+        raise NotImplementedError
+
     nparticles = hci.shape[0]
 
     # weight array
@@ -111,9 +125,13 @@ def _deposit_cic_3D(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
+    if weight_field.size > 0:
+        raise NotImplementedError
+
     nparticles = hci.shape[0]
 
     # weight array
@@ -179,9 +197,13 @@ def _deposit_tsc_1D(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
+    if weight_field.size > 0:
+        raise NotImplementedError
+
     nparticles = hci.shape[0]
 
     # weight array
@@ -208,9 +230,13 @@ def _deposit_tsc_2D(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
+    if weight_field.size > 0:
+        raise NotImplementedError
+
     nparticles = hci.shape[0]
 
     # weight arrays
@@ -253,9 +279,13 @@ def _deposit_tsc_3D(
     particles_x2,
     particles_x3,
     field,
+    weight_field,
     hci,
     out,
 ):
+    if weight_field.size > 0:
+        raise NotImplementedError
+
     nparticles = hci.shape[0]
 
     # weight arrays

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
 ]
 
 typecheck = [
-    "mypy==0.971",
+    "mypy==0.982",
     "numpy~=1.23",
 ]
 


### PR DESCRIPTION
closes #46 

Unfortunately this requires a breaking change in boundary recipes' extensibility (signatures are not backward compatible)


TODO:
- [x] survive CI
- [x] finish implementing weigth fields in all deposition recipes (clib)
- [x] minimal mirroring in the Python lib version
- [x] test coverage
- [x] validate implementation (by external use ?)
- [x] refactor builtin boundary recipes to take weight into account -> no-op
- [x] make sure performance for base case isn't significantly impacted (adding conditionals deep inside tight loops looks bad... but branch prediction should save us)
- [x] update docs
  - [x] explain why weight fields are necessary
  - [x] mathematical detail
  - [x] detail order of operations when weight fields are used in combination with boundary conditions
  - [x] note that *boundary oder is exposed* (both for deposited field and weight field)
  - [x] note that when a weight field is used, deposition array layers that are available in boundary recipes represent the extensive field rather than the intensive one being deposited 