### PR TITLE
ENH: minimal support for Grid.cell_volumes property (cartesian only)

### DIFF
--- a/gpgi/types.py
+++ b/gpgi/types.py
@@ -16,14 +16,12 @@ from typing import Dict
 from typing import Literal
 from typing import Protocol
 from typing import Tuple
-from typing import TYPE_CHECKING
 
 import numpy as np
 
 from ._boundaries import BoundaryRegistry
-
-if TYPE_CHECKING:
-    from ._typing import RealArray, HCIArray
+from ._typing import HCIArray
+from ._typing import RealArray
 
 BoundarySpec = Tuple[Tuple[str, str, str], ...]
 
@@ -232,6 +230,21 @@ class Grid(CoordinateValidatorMixin):
     @property
     def ndim(self) -> int:
         return len(self.axes)
+
+    @property
+    def cell_volumes(self) -> RealArray:
+        """
+        3D: (nx, ny, nz) array representing volumes
+        2D: (nx, ny) array representing surface
+        1D: (nx,) array representing widths (redundant with cell_widths)
+        """
+        widths = list(self.cell_widths.values())
+        if self.geometry is Geometry.CARTESIAN:
+            return cast(RealArray, np.prod(np.meshgrid(*widths), axis=0))
+        else:
+            raise NotImplementedError(
+                f"cell_volumes property is not implemented for {self.geometry}"
+            )
 
 
 class ParticleSet(CoordinateValidatorMixin):

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,0 +1,36 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from gpgi.api import load
+
+
+def test_cell_volumes_cartesian():
+    ds = load(
+        geometry="cartesian",
+        grid={
+            "cell_edges": {
+                "x": np.arange(11),
+                "y": np.arange(0, 1.1, 0.1),
+            }
+        },
+    )
+    expected = np.prod(np.meshgrid(np.ones(10), 0.1 * np.ones(10)), axis=0)
+    npt.assert_allclose(ds.grid.cell_volumes, expected, rtol=1e-15)
+
+
+def test_cell_volumes_curvilinear():
+    ds = load(
+        geometry="cylindrical",
+        grid={
+            "cell_edges": {
+                "radius": np.arange(11),
+                "azimuth": np.arange(0, 1.1, 0.1),
+            }
+        },
+    )
+    with pytest.raises(
+        NotImplementedError,
+        match=r"cell_volumes property is not implemented for Geometry\.CYLINDRICAL",
+    ):
+        ds.grid.cell_volumes


### PR DESCRIPTION
closes #34
The reason I didn't implement this earlier is that I didn't need it, and forsaw that it wouldn't be trivial for curvilinear geometries.
Now I have a need for this feature but I can live with it working only in cartesian geometry for now.