### PR TITLE
BUG: fix a bug in boundary condition treatment (erroneous data selection)

### DIFF
--- a/gpgi/types.py
+++ b/gpgi/types.py
@@ -540,9 +540,9 @@ class Dataset(ValidatorMixin):
 
                 same_side_ghost_layer_idx = [slice(None)] * self.grid.ndim
                 # f(-2)=-1, f(1)=0
-                same_side_ghost_layer_idx[iax] = (  # type:ignore [call-overload]
-                    active_index + 1
-                ) % 2
+                same_side_ghost_layer_idx[iax] = -(  # type:ignore [call-overload]
+                    (active_index + 1) % 2
+                )
 
                 opposite_side_active_layer_idx = [slice(None)] * self.grid.ndim
                 # f(-2)=1, f(1)=-2


### PR DESCRIPTION
the "wall" boundary condition is documented as conservative but the test I'm adding here shows that it's not (but "periodic" boundaries are !)

I must decide wether the documentation is wrong or the code is.