### PR TITLE
API: invert definitions of CYLINDRICAL and POLAR geometries

### DIFF
--- a/gpgi/types.py
+++ b/gpgi/types.py
@@ -139,8 +139,8 @@ class ValidatorMixin(GeometricData, ABC):
     def _validate_geometry(self) -> None:
         known_axes: dict[Geometry, tuple[Name, Name, Name]] = {
             Geometry.CARTESIAN: ("x", "y", "z"),
-            Geometry.POLAR: ("radius", "z", "azimuth"),
-            Geometry.CYLINDRICAL: ("radius", "azimuth", "z"),
+            Geometry.POLAR: ("radius", "azimuth", "z"),
+            Geometry.CYLINDRICAL: ("radius", "z", "azimuth"),
             Geometry.SPHERICAL: ("radius", "colatitude", "azimuth"),
             Geometry.EQUATORIAL: ("radius", "azimuth", "latitude"),
         }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -106,14 +106,18 @@ def test_unsorted_cell_edges():
         ("spherical", {"radius": np.arange(-1, 1)}, "radius", "min", 0),
         (
             "cylindrical",
-            {"radius": np.arange(10), "azimuth": np.arange(-10, 10)},
+            {
+                "radius": np.arange(10),
+                "z": np.arange(10),
+                "azimuth": np.arange(-10, 10),
+            },
             "azimuth",
             "min",
             0,
         ),
         (
             "cylindrical",
-            {"radius": np.arange(10), "azimuth": np.arange(10)},
+            {"radius": np.arange(10), "z": np.arange(10), "azimuth": np.arange(10)},
             "azimuth",
             "max",
             2 * np.pi,

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -26,7 +26,7 @@ def test_cell_volumes_curvilinear():
         grid={
             "cell_edges": {
                 "radius": np.arange(11),
-                "azimuth": np.arange(0, 1.1, 0.1),
+                "z": np.arange(0, 1.1, 0.1),
             }
         },
     )


### PR DESCRIPTION
:warning: This is a breaking change
I'm aligning the definitions of `Geometry.CYLINDRICAL` and `Geometry.POLAR` with the dominant usage in hydro-simulation code (Pluto, Idefix, MPI-AMRVAC ...)