### PR TITLE
UX: improve error messages in case of mixed dtypes

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -344,3 +344,15 @@ def test_depr_pic():
         ),
     ):
         ds.deposit("mass", method="pic")
+
+
+def test_float32_limit_validation():
+    gpgi.load(
+        geometry="cylindrical",
+        grid={
+            "cell_edges": {
+                "radius": [0, 1],
+                "azimuth": np.array([0, 2 * np.pi], dtype="float32"),
+            }
+        },
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -298,7 +298,7 @@ def test_identical_dtype_requirement():
 
     with pytest.raises(
         TypeError,
-        match=r"Got mixed data types \(\[dtype\('float32'\), dtype\('float64'\)\]\)",
+        match=r"Got mixed data types",
     ):
         gpgi.load(
             geometry="cartesian",
@@ -348,11 +348,28 @@ def test_depr_pic():
 
 def test_float32_limit_validation():
     gpgi.load(
-        geometry="cylindrical",
+        geometry="polar",
         grid={
             "cell_edges": {
-                "radius": [0, 1],
+                "radius": np.array([0, 1], dtype="float32"),
                 "azimuth": np.array([0, 2 * np.pi], dtype="float32"),
             }
         },
     )
+
+
+def test_float32_limit_invalidation():
+    # domain boundaries are validated before dtype consistency,
+    # we want to make sure that this fails *despite* being
+    # knowingly tolerant with the dtype of each individual
+    # coordinate array as we validate boundaries
+    with pytest.raises(TypeError, match=r"Grid received mixed data types"):
+        gpgi.load(
+            geometry="polar",
+            grid={
+                "cell_edges": {
+                    "radius": np.array([0, 1], dtype="float64"),
+                    "azimuth": np.array([0, 2 * np.pi], dtype="float32"),
+                }
+            },
+        )

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -25,7 +25,7 @@ def test_cell_volumes_curvilinear():
         geometry="cylindrical",
         grid={
             "cell_edges": {
-                "radius": np.arange(11),
+                "radius": np.arange(11, dtype="int64"),
                 "z": np.arange(0, 1.1, 0.1),
             }
         },


### PR DESCRIPTION
Add a missing test for #91 