### PR TITLE
BUG: resolve bugs with literal edge cases (particles living on the edge of the domain)"

### DIFF
--- a/gpgi/clib/_indexing.pyx
+++ b/gpgi/clib/_indexing.pyx
@@ -36,7 +36,11 @@ def _index_particles(
     """
     cdef Py_ssize_t ipart, particle_count
     cdef np.uint16_t iL, iR, idx
-    cdef real x
+
+    # reduce the chance of floating point arithmetic errors
+    # by forcing positions be read as double precision
+    # (instead of reading as the input type)
+    cdef np.float64_t x
 
     cdef int ndim
     if cell_edges_x3.shape[0] > 1:

--- a/gpgi/types.py
+++ b/gpgi/types.py
@@ -440,6 +440,13 @@ class Dataset(ValidatorMixin):
             dx=self.grid._dx,
             out=self._hci,
         )
+        for idim in range(self._hci.shape[1]):
+            # There are at leas two edge cases where we need clipping to correct raw indices:
+            # - particles that live exactly on the domain right edge will be indexed out of bound
+            # - single precision positions can lead to overshoots by simple effect of floating point arithmetics
+            #   (double precision isn't safe either, it's just safer (by a lot))
+            self._hci[:, idim].clip(1, self.grid.shape[idim], out=self._hci[:, idim])
+
         tstop = monotonic_ns()
         if verbose:
             print(

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -574,3 +574,32 @@ def test_partial_boundary():
         },
     )
     ds.boundary_recipes.register("my", myrecipe, skip_validation=False)
+
+
+@pytest.mark.parametrize("method", ["ngp", "cic", "tsc"])
+@pytest.mark.parametrize("dtype", ["float32", "float64"])
+def test_particles_on_domain_corners(method, dtype):
+    nx, ny, nz = 2, 3, 5
+    xlim = ylim = zlim = (0, 1)
+    nparticles = 6
+    ds = gpgi.load(
+        geometry="cartesian",
+        grid={
+            "cell_edges": {
+                "x": np.linspace(*xlim, nx + 1, dtype=dtype),
+                "y": np.linspace(*ylim, ny + 1, dtype=dtype),
+                "z": np.linspace(*zlim, nz + 1, dtype=dtype),
+            },
+        },
+        particles={
+            "coordinates": {
+                "x": np.array([0, 0, 0, 1, 1, 1], dtype=dtype),
+                "y": np.array([0, 1, 1, 0, 1, 1], dtype=dtype),
+                "z": np.array([1, 0, 1, 0, 0, 1], dtype=dtype),
+            },
+            "fields": {
+                "mass": np.ones(nparticles, dtype=dtype),
+            },
+        },
+    )
+    ds.deposit("mass", method=method)


### PR DESCRIPTION
- TST: add tests for literal corner cases
- BUG: reduce chances of floating point arithmetics corrupting indices
- BUG: clip indices to avoid crashes for particles exactly on the right edge
