### PR TITLE
BLD: migrate to Cython 3.0, forbid deprecated numpy API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
     "setuptools>=61.2",
-    "Cython>=0.29.22",
+    "Cython>=3.0, <3.1",
     "numpy>=1.25, <2.0; python_version >= '3.9'",
     "oldest-supported-numpy; python_version < '3.9'",
 ]

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,11 @@ def make_ext(path: str) -> Extension:
     name, _ = os.path.splitext(path)
     name = name.replace("/", ".")
 
+    define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+
     if sys.version_info >= (3, 9):
         # keep in sync with runtime requirements (pyproject.toml)
-        define_macros = [("NPY_TARGET_VERSION", "NPY_1_18_API_VERSION")]
-    else:
-        define_macros = []
+        define_macros.append(("NPY_TARGET_VERSION", "NPY_1_18_API_VERSION"))
 
     return Extension(
         name,


### PR DESCRIPTION
opening just a couple hours ahead of time (cython 3.0 is being deployed to PyPI)