### PR TITLE
BUG: fix error message so it's identical on numpy 1.x and 2.0

### DIFF
--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -405,8 +405,8 @@ class Dataset(ValidatorMixin):
         if self.particles.count == 0:
             return
         for ax, edges in self.grid.cell_edges.items():
-            domain_left = edges[0]
-            domain_right = edges[-1]
+            domain_left = float(edges[0])
+            domain_right = float(edges[-1])
             for x in self.particles.coordinates[ax]:
                 if x < domain_left:
                     raise ValueError(f"Got particle at {ax}={x} < {domain_left=}")


### PR DESCRIPTION
fix an error caught by future-proofing tests (see https://github.com/neutrinoceros/gpgi/actions/runs/5979714965/job/16224376441)