### PR TITLE
DEPR: expire deprecations and bump version to 1.0.0dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gpgi"
-version = "0.14.0"
+version = "1.0.0dev0"
 description = "A Generic Particle+Grid Interface"
 authors = [
     { name = "C.M.T. Robert" },

--- a/src/gpgi/__init__.py
+++ b/src/gpgi/__init__.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from .types import Dataset, FieldMap, Geometry, Grid, ParticleSet
 
-__version__ = "0.14.0"
+__version__ = "1.0.0dev0"
 
 
 def load(

--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -672,15 +672,6 @@ class Dataset(ValidatorMixin):
 
            Boundary recipes are applied the weight field (if any) first.
         """
-        if method in ("pic", "particle_in_cell"):
-            warnings.warn(
-                f"{method=!r} is a deprecated alias for method='ngp', "
-                "please use 'ngp' (or 'nearest_grid_point') directly",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            method = "ngp"
-
         if callable(method):
             from inspect import signature
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -320,37 +320,6 @@ def test_identical_dtype_requirement():
         )
 
 
-def test_depr_pic():
-    ds = gpgi.load(
-        geometry="cartesian",
-        grid={
-            "cell_edges": {
-                "x": np.array([0, 1.0]),
-                "y": np.array([0, 1.0]),
-                "z": np.array([0, 1.0]),
-            }
-        },
-        particles={
-            "coordinates": {
-                "x": np.array([0.0, 1.0]),
-                "y": np.array([0.0, 1.0]),
-                "z": np.array([0.0, 1.0]),
-            },
-            "fields": {
-                "mass": np.ones(2),
-            },
-        },
-    )
-    with pytest.warns(
-        DeprecationWarning,
-        match=(
-            r"method='pic' is a deprecated alias for method='ngp', "
-            r"please use 'ngp' \(or 'nearest_grid_point'\) directly"
-        ),
-    ):
-        ds.deposit("mass", method="pic")
-
-
 def test_float32_limit_validation():
     gpgi.load(
         geometry="polar",


### PR DESCRIPTION
In anticipation of #174, this happens to be the simplest solution to #180  (other solutions involve *modifying* this test, but it's going to be withdrawn soon anyway so let's not bother)