### PR TITLE
BUG: fix a spurious error when parsing invalid equatorial coordinates

### DIFF
--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -202,6 +202,7 @@ _AXES_LIMITS: dict[Name, tuple[float, float]] = {
     "radius": (0, float("inf")),
     "azimuth": (0, 2 * np.pi),
     "colatitude": (0, np.pi),
+    "latitude": (-np.pi / 2, np.pi / 2),
 }
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -162,6 +162,29 @@ def test_unsorted_cell_edges():
             "max",
             2 * np.pi,
         ),
+        pytest.param(
+            "equatorial",
+            {
+                "radius": np.arange(10.0),
+                "azimuth": np.arange(6.0),
+                "latitude": np.arange(-10.0, +10.0),
+            },
+            "latitude",
+            "min",
+            -np.pi / 2,
+            marks=pytest.mark.xfail,
+        ),
+        (
+            "equatorial",
+            {
+                "radius": np.arange(10.0),
+                "azimuth": np.arange(10.0),
+                "latitude": np.arange(2.0),
+            },
+            "azimuth",
+            "max",
+            2 * np.pi,
+        ),
     ],
 )
 def test_load_invalid_grid_coordinates(geometry, coords, axis, side, limit):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -162,7 +162,7 @@ def test_unsorted_cell_edges():
             "max",
             2 * np.pi,
         ),
-        pytest.param(
+        (
             "equatorial",
             {
                 "radius": np.arange(10.0),
@@ -172,7 +172,6 @@ def test_unsorted_cell_edges():
             "latitude",
             "min",
             -np.pi / 2,
-            marks=pytest.mark.xfail,
         ),
         (
             "equatorial",


### PR DESCRIPTION
- **TST: test cases for parsing equatorial geometries**
- **BUG: fix a spurious error when parsing invalid equatorial coordinates**
