### PR TITLE
TYP: refine auto-completion for grid.cell_edges and particles.coordinates

### DIFF
--- a/src/gpgi/__init__.py
+++ b/src/gpgi/__init__.py
@@ -1,9 +1,9 @@
 """gpgi: Fast particle deposition at post-processing time."""
 
 from importlib.util import find_spec
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
-from ._typing import _GridDict, _ParticleSetDict
+from ._typing import FieldMap, GridDict, ParticleSetDict
 from .types import Dataset, Geometry, Grid, ParticleSet
 
 _IS_PY_LIB = find_spec("gpgi._lib").origin.endswith(".py")  # type: ignore [union-attr]
@@ -12,8 +12,8 @@ _IS_PY_LIB = find_spec("gpgi._lib").origin.endswith(".py")  # type: ignore [unio
 def load(
     *,
     geometry: Literal["cartesian", "polar", "cylindrical", "spherical", "equatorial"],
-    grid: _GridDict,
-    particles: _ParticleSetDict | None = None,
+    grid: GridDict,
+    particles: ParticleSetDict | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> Dataset:
     r"""
@@ -50,7 +50,7 @@ def load(
         raise ValueError("grid dictionary missing required key 'cell_edges'")
     _grid = Grid(
         _geometry,
-        cell_edges=grid["cell_edges"],
+        cell_edges=cast(FieldMap, grid["cell_edges"]),
         fields=grid.get("fields"),
     )
 
@@ -60,7 +60,7 @@ def load(
             raise ValueError("particles dictionary missing required key 'coordinates'")
         _particles = ParticleSet(
             _geometry,
-            coordinates=particles["coordinates"],
+            coordinates=cast(FieldMap, particles["coordinates"]),
             fields=particles.get("fields"),
         )
 

--- a/src/gpgi/_typing.py
+++ b/src/gpgi/_typing.py
@@ -15,14 +15,53 @@ HCIArray = npt.NDArray[np.uint16]
 
 
 Name = str
-FieldMap = dict[Name, np.ndarray]
+FieldMap = dict[str, np.ndarray]
 
 
-class _GridDict(TypedDict):
-    cell_edges: FieldMap
+class CartesianCoordinates(TypedDict):
+    x: np.ndarray
+    y: NotRequired[np.ndarray]
+    z: NotRequired[np.ndarray]
+
+
+class CylindricalCoordinates(TypedDict):
+    radius: np.ndarray
+    azimuth: NotRequired[np.ndarray]
+    z: NotRequired[np.ndarray]
+
+
+class PolarCoordinates(TypedDict):
+    radius: np.ndarray
+    z: NotRequired[np.ndarray]
+    azimuth: NotRequired[np.ndarray]
+
+
+class SphericalCoordinates(TypedDict):
+    colatitude: np.ndarray
+    radius: NotRequired[np.ndarray]
+    azimuth: NotRequired[np.ndarray]
+
+
+class EquatorialCoordinates(TypedDict):
+    radius: np.ndarray
+    latitude: NotRequired[np.ndarray]
+    azimuth: NotRequired[np.ndarray]
+
+
+CoordMap = (
+    CartesianCoordinates
+    | CylindricalCoordinates
+    | PolarCoordinates
+    | SphericalCoordinates
+    | EquatorialCoordinates
+)
+
+
+class GridDict(TypedDict):
+    cell_edges: CoordMap
     fields: NotRequired[FieldMap]
 
 
-class _ParticleSetDict(TypedDict):
-    coordinates: FieldMap
+class ParticleSetDict(TypedDict):
+    coordinates: CoordMap
     fields: NotRequired[FieldMap]

--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -128,7 +128,7 @@ class ValidatorMixin(GeometricData, ABC):
     @abstractmethod
     def _validate(self) -> None: ...
 
-    def _validate_fieldmaps(
+    def _validate_FieldMaps(
         self,
         *fmaps: FieldMap | None,
         require_shape_equality: bool = False,
@@ -294,8 +294,8 @@ class Grid(_CoordinateValidatorMixin):
     def _validate(self) -> None:
         self._validate_geometry()
         self._validate_coordinates()
-        self._validate_fieldmaps(self.cell_edges, ndim=1, require_sorted=True)
-        self._validate_fieldmaps(
+        self._validate_FieldMaps(self.cell_edges, ndim=1, require_sorted=True)
+        self._validate_FieldMaps(
             self.fields,
             size=self.size,
             ndim=self.ndim,
@@ -375,7 +375,7 @@ class ParticleSet(_CoordinateValidatorMixin):
     def _validate(self) -> None:
         self._validate_geometry()
         self._validate_coordinates()
-        self._validate_fieldmaps(
+        self._validate_FieldMaps(
             self.coordinates, self.fields, require_shape_equality=True, ndim=1
         )
 


### PR DESCRIPTION
This helps with auto completion in IDEs, unfortunately all hell breaks loose when it comes to type checking so I'll keep this as a draft for now.

Note that `TypeExpr` (to be released in typing-extensions 4.13 and maybe Python 3.14) may offer a practical solution in the future.

I may also need to revise `gpgi.load`'s API to take a single `TypedDict` argument.