### PR TITLE
API: do not emit a warning when depositing on a single cell

### DIFF
--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -689,11 +689,6 @@ class Dataset(ValidatorMixin):
 
             func = _BUILTIN_METHODS[mkey][self.grid.ndim - 1]
 
-        if self.grid.size == 1:
-            warnings.warn(
-                "Depositing on a single-cell grid is undefined behavior",
-                stacklevel=2,
-            )
         if self.particles.count == 0:
             raise TypeError("Cannot deposit particle fields on a particle-less dataset")
         if not self.particles.fields:

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -61,10 +61,8 @@ def test_single_cell_grid(method):
             "fields": {"mass": np.ones(10, dtype="float64")},
         },
     )
-    with pytest.warns(
-        UserWarning, match="Depositing on a single-cell grid is undefined behavior"
-    ):
-        ds.deposit("mass", method=method)
+    out = ds.deposit("mass", method=method, return_ghost_padded_array=True)
+    assert np.sum(out) == ds.particles.count
 
 
 def test_missing_particles():


### PR DESCRIPTION
This warning was never really accurate and was really about infinite-size boxes, which are now disallowed.