### PR TITLE
TST: add thread-safety tests for host-cell-index computation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,30 @@ jobs:
         path: gpgi_pytest_mpl_new_baseline/*
         if-no-files-found: ignore
 
+  concurrency-tests:
+    name: Thread concurrency tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.x
+
+    - uses: yezz123/setup-uv@v4
+      with:
+        uv-version: 0.2.33
+        uv-venv: .venv
+
+    - name: Build library
+      run: uv pip install .
+
+    - run: uv pip install --requirement requirements/tests.txt
+
+    - name: Run Concurrency Tests
+      run: |
+        pytest --color=yes --count 500 tests/test_concurrent.py
 
   coverage:
     name: Combine & check coverage.

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,5 @@
 coverage[toml]>=6.5
 pytest>=7.0.0
 pytest-mpl>=0.16.1
+pytest-repeat>=0.9.3
 matplotlib>=3.5
-# https://github.com/matplotlib/matplotlib/issues/28551
-matplotlib!=3.9.1 ; platform_system=='Windows'

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -40,8 +40,9 @@ def test__setup_host_cell_index_concurrent_threading():
     def closure():
         # Ensure that all threads reach this point before concurrent execution.
         barrier.wait()
-        ds._setup_host_cell_index()
-        results.append(id(ds._hci))
+        hci = ds._setup_host_cell_index()
+        assert ds.host_cell_index is hci
+        results.append(id(hci))
 
     # Spawn n threads that call call_unsafe concurrently.
     workers = []
@@ -86,8 +87,9 @@ def test__setup_host_cell_index_concurrent_pool():
     def closure():
         # Ensure that all threads reach this point before concurrent execution.
         barrier.wait()
-        ds._setup_host_cell_index()
-        results.append(id(ds._hci))
+        hci = ds._setup_host_cell_index()
+        assert ds.host_cell_index is hci
+        results.append(id(hci))
 
     with ThreadPoolExecutor(max_workers=n_threads) as executor:
         futures = [executor.submit(closure) for _ in range(n_threads)]

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -1,0 +1,98 @@
+# exercise some thread concurrency
+# https://py-free-threading.github.io/debugging/
+
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+
+import gpgi
+
+prng = np.random.default_rng()
+
+
+def test__setup_host_cell_index_concurrent_threading():
+    # Defines a thread barrier that will be spawned before parallel execution
+    # this increases the probability of concurrent access clashes.
+    n_threads = 10
+    barrier = threading.Barrier(n_threads)
+
+    # This object will be shared by all the threads.
+    ds = gpgi.load(
+        geometry="cartesian",
+        grid={
+            "cell_edges": {
+                "x": np.linspace(-0.1, 1.1, 13),
+                "y": np.linspace(-0.1, 1.1, 13),
+            },
+        },
+        particles={
+            "coordinates": {
+                "x": prng.random(10_000),
+                "y": prng.random(10_000),
+            }
+        },
+    )
+
+    results = []
+
+    def closure():
+        # Ensure that all threads reach this point before concurrent execution.
+        barrier.wait()
+        ds._setup_host_cell_index()
+        results.append(id(ds._hci))
+
+    # Spawn n threads that call call_unsafe concurrently.
+    workers = []
+    for _ in range(0, n_threads):
+        workers.append(threading.Thread(target=closure))
+
+    for worker in workers:
+        worker.start()
+
+    for worker in workers:
+        worker.join()
+
+    # Check results: verify that all threads see the same array
+    assert len(set(results)) == 1
+
+
+def test__setup_host_cell_index_concurrent_pool():
+    # Defines a thread barrier that will be spawned before parallel execution
+    # this increases the probability of concurrent access clashes.
+    n_threads = 10
+    barrier = threading.Barrier(n_threads)
+
+    # This object will be shared by all the threads.
+    ds = gpgi.load(
+        geometry="cartesian",
+        grid={
+            "cell_edges": {
+                "x": np.linspace(-0.1, 1.1, 13),
+                "y": np.linspace(-0.1, 1.1, 13),
+            },
+        },
+        particles={
+            "coordinates": {
+                "x": prng.random(10_000),
+                "y": prng.random(10_000),
+            }
+        },
+    )
+
+    results = []
+
+    def closure():
+        # Ensure that all threads reach this point before concurrent execution.
+        barrier.wait()
+        ds._setup_host_cell_index()
+        results.append(id(ds._hci))
+
+    with ThreadPoolExecutor(max_workers=n_threads) as executor:
+        futures = [executor.submit(closure) for _ in range(n_threads)]
+
+    results = [f.result() for f in futures]
+
+    # Check results: verify that all threads see the same array
+    assert len(set(results)) == 1


### PR DESCRIPTION
Local testing seems to indicate that the function is de-facto sort-of thread-safe already because of its fast path mechanism, but I want to start checking for it systematically and maybe make the implementation explicitly thread-aware.