### PR TITLE
ENH: implement thread-safe inplace sorting

### DIFF
--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -622,7 +622,9 @@ class Dataset(ValidatorMixin):
         return bool(np.all(hci == hci[sort_key]))
 
     def sorted(
-        self, axes: tuple[int, ...] | None = None, inplace: bool = False
+        self,
+        axes: tuple[int, ...] | None = None,
+        inplace: bool = False,
     ) -> Self:
         r"""
         Return a copy of this dataset with particles sorted by host cell index.

--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -624,6 +624,7 @@ class Dataset(ValidatorMixin):
     def sorted(
         self,
         axes: tuple[int, ...] | None = None,
+        *,
         inplace: bool = False,
     ) -> Self:
         r"""

--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -619,7 +619,9 @@ class Dataset(ValidatorMixin):
         hci = self.host_cell_index
         return bool(np.all(hci == hci[sort_key]))
 
-    def sorted(self, axes: tuple[int, ...] | None = None) -> Self:
+    def sorted(
+        self, axes: tuple[int, ...] | None = None, inplace: bool = False
+    ) -> Self:
         r"""
         Return a copy of this dataset with particles sorted by host cell index.
 
@@ -627,6 +629,10 @@ class Dataset(ValidatorMixin):
         ----------
         axes: tuple[int, ...]
             specify in which order axes should be used for sorting.
+
+        inplace: bool (default: False)
+            If True, sort the dataset in place instead of creating a copy.
+            This option is thread-safe.
         """
         sort_key = self._get_sort_key(axes or self._default_sort_axes)
 

--- a/src/gpgi/types.py
+++ b/src/gpgi/types.py
@@ -634,7 +634,16 @@ class Dataset(ValidatorMixin):
             If True, sort the dataset in place instead of creating a copy.
             This option is thread-safe.
         """
-        sort_key = self._get_sort_key(axes or self._default_sort_axes)
+        sort_axes = axes or self._default_sort_axes
+        sort_key = self._get_sort_key(sort_axes)
+        if inplace:
+            for name, arr in self.particles.coordinates.items():
+                self.particles.coordinates[name] = arr[sort_key]
+            for name, arr in self.particles.fields.items():
+                self.particles.fields[name] = arr[sort_key]
+            # invalidate host cell index
+            self._hci = None
+            return self
 
         return type(self)(
             geometry=self.geometry,

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -4,6 +4,7 @@
 
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from random import shuffle
 
 import numpy as np
 
@@ -103,10 +104,12 @@ class TestSortInPlace:
             assert not ds.is_sorted()
 
             barrier.wait()
-            ds_out = ds.sorted(inplace=True)
+            for _ in range(5):
+                axes = shuffle([0, 1, 2])
+                ds_out = ds.sorted(axes, inplace=True)
 
-            assert ds.is_sorted()
-            assert ds_out is ds
+                assert ds.is_sorted(axes=axes)
+                assert ds_out is ds
 
         workers = []
         for _ in range(0, N_THREADS):

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -105,7 +105,9 @@ class TestSortInPlace:
 
             barrier.wait()
             for _ in range(5):
-                axes = shuffle([0, 1, 2])
+                axes_list = [0, 1, 2]
+                shuffle(axes_list)
+                axes = tuple(axes_list)
                 ds_out = ds.sorted(axes, inplace=True)
 
                 assert ds.is_sorted(axes=axes)


### PR DESCRIPTION
The thread-safe part is (currently) a lie, hopefully one that shows in CI as it does locally.
This is mostly a pretext to exercise thread-safe patterns, but I didn't get the hang of it just yet.