### PR TITLE
API: forbid overrides in `BoundaryRegistry.register` unless unsafe mutations are explicitly allowed.

### DIFF
--- a/tests/test_boundary_registry.py
+++ b/tests/test_boundary_registry.py
@@ -1,0 +1,51 @@
+import pytest
+
+from gpgi._boundaries import BoundaryRegistry
+
+
+def test_boundary_register_overrides():
+    registry = BoundaryRegistry()
+
+    def test_recipe1(
+        same_side_active_layer,
+        same_side_ghost_layer,
+        opposite_side_active_layer,
+        opposite_side_ghost_layer,
+        weight_same_side_active_layer,
+        weight_same_side_ghost_layer,
+        weight_opposite_side_active_layer,
+        weight_opposite_side_ghost_layer,
+        side,
+        metadata,
+    ): ...
+    def test_recipe2(
+        same_side_active_layer,
+        same_side_ghost_layer,
+        opposite_side_active_layer,
+        opposite_side_ghost_layer,
+        weight_same_side_active_layer,
+        weight_same_side_ghost_layer,
+        weight_opposite_side_active_layer,
+        weight_opposite_side_ghost_layer,
+        side,
+        metadata,
+    ): ...
+
+    registry.register("test1", test_recipe1)
+    assert registry["test1"] is test_recipe1
+
+    # registering the same function a second time shouldn't raise
+    registry.register("test1", test_recipe1)
+
+    with pytest.raises(
+        ValueError,
+        match="Another function is already registered with key='test1'",
+    ):
+        registry.register("test1", test_recipe2)
+
+    # check that we raised in time to preserve state
+    assert registry["test1"] is test_recipe1
+
+    # if we explicitly allow unsafe mutations, this should not raise
+    registry.register("test1", test_recipe2, allow_unsafe_override=True)
+    assert registry["test1"] is test_recipe2

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -8,6 +8,7 @@ from concurrent.futures import ThreadPoolExecutor
 import numpy as np
 
 import gpgi
+from gpgi._boundaries import BoundaryRegistry
 
 prng = np.random.default_rng()
 
@@ -84,6 +85,93 @@ class TestSetupHostCellIndex:
             hci = ds._setup_host_cell_index()
             assert ds.host_cell_index is hci
             results.append(id(hci))
+
+        with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+            futures = [executor.submit(closure) for _ in range(N_THREADS)]
+
+        results = [f.result() for f in futures]
+        self.check(results)
+
+
+class TestBoundaryRegistry:
+    def check(self, results):
+        # Check results: verify that all threads get the same obj
+        assert len(set(results)) == 1
+
+    def test_concurrent_threading(self):
+        # Defines a thread barrier that will be spawned before parallel execution
+        # this increases the probability of concurrent access clashes.
+        barrier = threading.Barrier(N_THREADS)
+
+        # This object will be shared by all the threads.
+        registry = BoundaryRegistry()
+
+        def test_recipe(
+            same_side_active_layer,
+            same_side_ghost_layer,
+            opposite_side_active_layer,
+            opposite_side_ghost_layer,
+            weight_same_side_active_layer,
+            weight_same_side_ghost_layer,
+            weight_opposite_side_active_layer,
+            weight_opposite_side_ghost_layer,
+            side,
+            metadata,
+        ): ...
+
+        results = []
+
+        def closure():
+            assert "test" not in registry
+
+            # Ensure that all threads reach this point before concurrent execution.
+            barrier.wait()
+            registry.register("test", test_recipe)
+            results.append(registry["test"])
+
+        # Spawn n threads that call _setup_host_cell_index concurrently.
+        workers = []
+        for _ in range(0, N_THREADS):
+            workers.append(threading.Thread(target=closure))
+
+        for worker in workers:
+            worker.start()
+
+        for worker in workers:
+            worker.join()
+
+        self.check(results)
+
+    def test_concurrent_pool(self):
+        # Defines a thread barrier that will be spawned before parallel execution
+        # this increases the probability of concurrent access clashes.
+        barrier = threading.Barrier(N_THREADS)
+
+        # This object will be shared by all the threads.
+        registry = BoundaryRegistry()
+
+        def test_recipe(
+            same_side_active_layer,
+            same_side_ghost_layer,
+            opposite_side_active_layer,
+            opposite_side_ghost_layer,
+            weight_same_side_active_layer,
+            weight_same_side_ghost_layer,
+            weight_opposite_side_active_layer,
+            weight_opposite_side_ghost_layer,
+            side,
+            metadata,
+        ): ...
+
+        results = []
+
+        def closure():
+            assert "test" not in registry
+
+            # Ensure that all threads reach this point before concurrent execution.
+            barrier.wait()
+            registry.register("test", test_recipe)
+            results.append(registry["test"])
 
         with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
             futures = [executor.submit(closure) for _ in range(N_THREADS)]

--- a/tests/test_deposit.py
+++ b/tests/test_deposit.py
@@ -396,54 +396,6 @@ def test_register_invalid_boundary_recipe():
         ds.boundary_recipes.register("my", _my_recipe)
 
 
-def test_warn_register_override(capsys):
-    nx = ny = 64
-    nparticles = 100
-
-    prng = np.random.RandomState(0)
-    ds = gpgi.load(
-        geometry="cartesian",
-        grid={
-            "cell_edges": {
-                "x": np.linspace(-1, 1, nx),
-                "y": np.linspace(-1, 1, ny),
-            },
-        },
-        particles={
-            "coordinates": {
-                "x": 2 * (prng.normal(0.5, 0.25, nparticles) % 1 - 0.5),
-                "y": 2 * (prng.normal(0.5, 0.25, nparticles) % 1 - 0.5),
-            },
-            "fields": {
-                "mass": np.ones(nparticles),
-            },
-        },
-        metadata={"fac": 1},
-    )
-
-    def _my_recipe(
-        same_side_active_layer,
-        same_side_ghost_layer,
-        opposite_side_active_layer,
-        opposite_side_ghost_layer,
-        weight_same_side_active_layer,
-        weight_same_side_ghost_layer,
-        weight_opposite_side_active_layer,
-        weight_opposite_side_ghost_layer,
-        side,
-        metadata,
-    ):
-        print("gotcha")
-        return same_side_active_layer * metadata["fac"]
-
-    with pytest.warns(UserWarning, match="Overriding existing method 'open'"):
-        ds.boundary_recipes.register("open", _my_recipe)
-
-    ds.deposit("mass", method="tsc")
-    out, err = capsys.readouterr()
-    assert out == "gotcha\n" * 4
-
-
 def test_register_custom_boundary_recipe(sample_2D_dataset):
     def _my_recipe(
         same_side_active_layer,


### PR DESCRIPTION
closes #239