### PR TITLE
PERF: release the GIL in hotloops

### DIFF
--- a/src/gpgi/_lib.pyx
+++ b/src/gpgi/_lib.pyx
@@ -61,57 +61,58 @@ def _index_particles(
 
     particle_count = particles_x1.shape[0]
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        if dx[0] > 0:
-            out[ipart, 0] = int((x - cell_edges_x1[0]) // dx[0])
-        else:
-            iL = 1
-            iR = cell_edges_x1.shape[0] - 2
-            idx = (iL + iR) // 2
-            while idx != iL:
-                if cell_edges_x1[idx] > x:
-                    iR = idx
-                else:
-                    iL = idx
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            if dx[0] > 0:
+                out[ipart, 0] = int((x - cell_edges_x1[0]) // dx[0])
+            else:
+                iL = 1
+                iR = cell_edges_x1.shape[0] - 2
                 idx = (iL + iR) // 2
-            out[ipart, 0] = idx
+                while idx != iL:
+                    if cell_edges_x1[idx] > x:
+                        iR = idx
+                    else:
+                        iL = idx
+                    idx = (iL + iR) // 2
+                out[ipart, 0] = idx
 
-        if ndim < 2:
-            continue
+            if ndim < 2:
+                continue
 
-        x = particles_x2[ipart]
-        if dx[1] > 0:
-            out[ipart, 1] = int((x - cell_edges_x2[0]) // dx[1])
-        else:
-            iL = 1
-            iR = cell_edges_x2.shape[0] - 2
-            idx = (iL + iR) // 2
-            while idx != iL:
-                if cell_edges_x2[idx] > x:
-                    iR = idx
-                else:
-                    iL = idx
+            x = particles_x2[ipart]
+            if dx[1] > 0:
+                out[ipart, 1] = int((x - cell_edges_x2[0]) // dx[1])
+            else:
+                iL = 1
+                iR = cell_edges_x2.shape[0] - 2
                 idx = (iL + iR) // 2
-            out[ipart, 1] = idx
+                while idx != iL:
+                    if cell_edges_x2[idx] > x:
+                        iR = idx
+                    else:
+                        iL = idx
+                    idx = (iL + iR) // 2
+                out[ipart, 1] = idx
 
-        if ndim < 3:
-            continue
+            if ndim < 3:
+                continue
 
-        x = particles_x3[ipart]
-        if dx[2] > 0:
-            out[ipart, 2] = int((x - cell_edges_x3[0]) // dx[2])
-        else:
-            iL = 1
-            iR = cell_edges_x3.shape[0] - 2
-            idx = (iL + iR) // 2
-            while idx != iL:
-                if cell_edges_x3[idx] > x:
-                    iR = idx
-                else:
-                    iL = idx
+            x = particles_x3[ipart]
+            if dx[2] > 0:
+                out[ipart, 2] = int((x - cell_edges_x3[0]) // dx[2])
+            else:
+                iL = 1
+                iR = cell_edges_x3.shape[0] - 2
                 idx = (iL + iR) // 2
-            out[ipart, 2] = idx
+                while idx != iL:
+                    if cell_edges_x3[idx] > x:
+                        iR = idx
+                    else:
+                        iL = idx
+                    idx = (iL + iR) // 2
+                out[ipart, 2] = idx
 
 
 @cython.boundscheck(False)
@@ -141,12 +142,13 @@ def _deposit_ngp_1D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        i = hci_v[ipart][0]
-        if no_weight:
-            out_v[i] += field_v[ipart]
-        else:
-            out_v[i] += field_v[ipart] * wfield_v[ipart]
+    with nogil:
+        for ipart in range(particle_count):
+            i = hci_v[ipart][0]
+            if no_weight:
+                out_v[i] += field_v[ipart]
+            else:
+                out_v[i] += field_v[ipart] * wfield_v[ipart]
 
 
 @cython.boundscheck(False)
@@ -176,13 +178,14 @@ def _deposit_ngp_2D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        i = hci_v[ipart][0]
-        j = hci_v[ipart][1]
-        if no_weight:
-            out_v[i][j] += field_v[ipart]
-        else:
-            out_v[i][j] += field_v[ipart] * wfield_v[ipart]
+    with nogil:
+        for ipart in range(particle_count):
+            i = hci_v[ipart][0]
+            j = hci_v[ipart][1]
+            if no_weight:
+                out_v[i][j] += field_v[ipart]
+            else:
+                out_v[i][j] += field_v[ipart] * wfield_v[ipart]
 
 
 @cython.boundscheck(False)
@@ -212,14 +215,15 @@ def _deposit_ngp_3D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        i = hci_v[ipart][0]
-        j = hci_v[ipart][1]
-        k = hci_v[ipart][2]
-        if no_weight:
-            out_v[i][j][k] += field_v[ipart]
-        else:
-            out_v[i][j][k] += field_v[ipart] * wfield_v[ipart]
+    with nogil:
+        for ipart in range(particle_count):
+            i = hci_v[ipart][0]
+            j = hci_v[ipart][1]
+            k = hci_v[ipart][2]
+            if no_weight:
+                out_v[i][j][k] += field_v[ipart]
+            else:
+                out_v[i][j][k] += field_v[ipart] * wfield_v[ipart]
 
 
 @cython.cdivision(True)
@@ -254,20 +258,21 @@ def _deposit_cic_1D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        ci = hci[ipart, 0]
-        d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
-        ci_start = ci + <np.uint16_t>fmin(0, floor(2*d)-1)
-        w[0] = 0.5 - d + fmin(1, floor(2*d))
-        w[1] = 1 - w[0]
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            ci = hci[ipart, 0]
+            d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
+            ci_start = ci + <np.uint16_t>fmin(0, floor(2*d)-1)
+            w[0] = 0.5 - d + fmin(1, floor(2*d))
+            w[1] = 1 - w[0]
 
-        for i in range(2):
-            oci = ci_start + i
-            if no_weight:
-                out_v[oci] += w[i] * field_v[ipart]
-            else:
-                out_v[oci] += w[i] * field_v[ipart] * wfield_v[ipart]
+            for i in range(2):
+                oci = ci_start + i
+                if no_weight:
+                    out_v[oci] += w[i] * field_v[ipart]
+                else:
+                    out_v[oci] += w[i] * field_v[ipart] * wfield_v[ipart]
 
 
 @cython.cdivision(True)
@@ -303,33 +308,34 @@ def _deposit_cic_2D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        ci = hci[ipart, 0]
-        d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
-        ci_start = ci + <np.uint16_t>fmin(0, floor(2*d)-1)
-        w1[0] = 0.5 - d + fmin(1, floor(2*d))
-        w1[1] = 1 - w1[0]
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            ci = hci[ipart, 0]
+            d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
+            ci_start = ci + <np.uint16_t>fmin(0, floor(2*d)-1)
+            w1[0] = 0.5 - d + fmin(1, floor(2*d))
+            w1[1] = 1 - w1[0]
 
-        x = particles_x2[ipart]
-        cj = hci[ipart, 1]
-        d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
-        cj_start = cj + <np.uint16_t>fmin(0, floor(2*d)-1)
-        w2[0] = 0.5 - d + fmin(1, floor(2*d))
-        w2[1] = 1 - w2[0]
+            x = particles_x2[ipart]
+            cj = hci[ipart, 1]
+            d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
+            cj_start = cj + <np.uint16_t>fmin(0, floor(2*d)-1)
+            w2[0] = 0.5 - d + fmin(1, floor(2*d))
+            w2[1] = 1 - w2[0]
 
-        for i in range(2):
-            for j in range(2):
-                w[i][j] = w1[i] * w2[j]
+            for i in range(2):
+                for j in range(2):
+                    w[i][j] = w1[i] * w2[j]
 
-        for i in range(2):
-            oci = ci_start + i
-            for j in range(2):
-                ocj = cj_start + j
-                if no_weight:
-                    out_v[oci, ocj] += w[i][j] * field_v[ipart]
-                else:
-                    out_v[oci, ocj] += w[i][j] * field_v[ipart] * wfield_v[ipart]
+            for i in range(2):
+                oci = ci_start + i
+                for j in range(2):
+                    ocj = cj_start + j
+                    if no_weight:
+                        out_v[oci, ocj] += w[i][j] * field_v[ipart]
+                    else:
+                        out_v[oci, ocj] += w[i][j] * field_v[ipart] * wfield_v[ipart]
 
 
 @cython.cdivision(True)
@@ -365,43 +371,44 @@ def _deposit_cic_3D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        ci = hci[ipart, 0]
-        d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
-        ci_start = ci + <np.uint16_t>fmin(0, floor(2*d)-1)
-        w1[0] = 0.5 - d + fmin(1, floor(2*d))
-        w1[1] = 1 - w1[0]
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            ci = hci[ipart, 0]
+            d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
+            ci_start = ci + <np.uint16_t>fmin(0, floor(2*d)-1)
+            w1[0] = 0.5 - d + fmin(1, floor(2*d))
+            w1[1] = 1 - w1[0]
 
-        x = particles_x2[ipart]
-        cj = hci[ipart, 1]
-        d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
-        cj_start = cj + <np.uint16_t>fmin(0, floor(2*d)-1)
-        w2[0] = 0.5 - d + fmin(1, floor(2*d))
-        w2[1] = 1 - w2[0]
+            x = particles_x2[ipart]
+            cj = hci[ipart, 1]
+            d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
+            cj_start = cj + <np.uint16_t>fmin(0, floor(2*d)-1)
+            w2[0] = 0.5 - d + fmin(1, floor(2*d))
+            w2[1] = 1 - w2[0]
 
-        x = particles_x3[ipart]
-        ck = hci[ipart, 2]
-        d = (x - cell_edges_x3[ck]) / (cell_edges_x3[ck + 1] - cell_edges_x3[ck])
-        ck_start = ck + <np.uint16_t>fmin(0, floor(2*d)-1)
-        w3[0] = 0.5 - d + fmin(1, floor(2*d))
-        w3[1] = 1 - w3[0]
+            x = particles_x3[ipart]
+            ck = hci[ipart, 2]
+            d = (x - cell_edges_x3[ck]) / (cell_edges_x3[ck + 1] - cell_edges_x3[ck])
+            ck_start = ck + <np.uint16_t>fmin(0, floor(2*d)-1)
+            w3[0] = 0.5 - d + fmin(1, floor(2*d))
+            w3[1] = 1 - w3[0]
 
-        for i in range(2):
-            for j in range(2):
-                for k in range(2):
-                    w[i][j][k] = w1[i] * w2[j] * w3[k]
+            for i in range(2):
+                for j in range(2):
+                    for k in range(2):
+                        w[i][j][k] = w1[i] * w2[j] * w3[k]
 
-        for i in range(2):
-            oci = ci_start + i
-            for j in range(2):
-                ocj = cj_start + j
-                for k in range(2):
-                    ock = ck_start + k
-                    if no_weight:
-                        out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart]
-                    else:
-                        out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart] * wfield_v[ipart]  # noqa E501
+            for i in range(2):
+                oci = ci_start + i
+                for j in range(2):
+                    ocj = cj_start + j
+                    for k in range(2):
+                        ock = ck_start + k
+                        if no_weight:
+                            out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart]
+                        else:
+                            out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart] * wfield_v[ipart]  # noqa E501
 
 
 @cython.cdivision(True)
@@ -435,20 +442,21 @@ def _deposit_tsc_1D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        ci = hci[ipart, 0]
-        d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
-        w[0] = 0.5 * (1 - d) ** 2
-        w[1] = 0.75 - (d - 0.5) ** 2
-        w[2] = 0.5 * d**2
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            ci = hci[ipart, 0]
+            d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
+            w[0] = 0.5 * (1 - d) ** 2
+            w[1] = 0.75 - (d - 0.5) ** 2
+            w[2] = 0.5 * d**2
 
-        for i in range(3):
-            oci = ci - 1 + i
-            if no_weight:
-                out_v[oci] += w[i] * field_v[ipart]
-            else:
-                out_v[oci] += w[i] * field_v[ipart] * wfield_v[ipart]
+            for i in range(3):
+                oci = ci - 1 + i
+                if no_weight:
+                    out_v[oci] += w[i] * field_v[ipart]
+                else:
+                    out_v[oci] += w[i] * field_v[ipart] * wfield_v[ipart]
 
 
 @cython.cdivision(True)
@@ -483,33 +491,34 @@ def _deposit_tsc_2D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        ci = hci[ipart, 0]
-        d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
-        w1[0] = 0.5 * (1 - d) ** 2
-        w1[1] = 0.75 - (d - 0.5) ** 2
-        w1[2] = 0.5 * d**2
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            ci = hci[ipart, 0]
+            d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
+            w1[0] = 0.5 * (1 - d) ** 2
+            w1[1] = 0.75 - (d - 0.5) ** 2
+            w1[2] = 0.5 * d**2
 
-        x = particles_x2[ipart]
-        cj = hci[ipart, 1]
-        d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
-        w2[0] = 0.5 * (1 - d) ** 2
-        w2[1] = 0.75 - (d - 0.5) ** 2
-        w2[2] = 0.5 * d**2
+            x = particles_x2[ipart]
+            cj = hci[ipart, 1]
+            d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
+            w2[0] = 0.5 * (1 - d) ** 2
+            w2[1] = 0.75 - (d - 0.5) ** 2
+            w2[2] = 0.5 * d**2
 
-        for i in range(3):
-            for j in range(3):
-                w[i][j] = w1[i] * w2[j]
+            for i in range(3):
+                for j in range(3):
+                    w[i][j] = w1[i] * w2[j]
 
-        for i in range(3):
-            oci = ci - 1 + i
-            for j in range(3):
-                ocj = cj - 1 + j
-                if no_weight:
-                    out_v[oci, ocj] += w[i][j] * field_v[ipart]
-                else:
-                    out_v[oci, ocj] += w[i][j] * field_v[ipart] * wfield_v[ipart]
+            for i in range(3):
+                oci = ci - 1 + i
+                for j in range(3):
+                    ocj = cj - 1 + j
+                    if no_weight:
+                        out_v[oci, ocj] += w[i][j] * field_v[ipart]
+                    else:
+                        out_v[oci, ocj] += w[i][j] * field_v[ipart] * wfield_v[ipart]
 
 
 @cython.cdivision(True)
@@ -544,40 +553,41 @@ def _deposit_tsc_3D(
     cdef real[:] wfield_v = weight_field
     cdef bint no_weight = (lw == 0)
 
-    for ipart in range(particle_count):
-        x = particles_x1[ipart]
-        ci = hci[ipart, 0]
-        d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
-        w1[0] = 0.5 * (1 - d) ** 2
-        w1[1] = 0.75 - (d - 0.5) ** 2
-        w1[2] = 0.5 * d**2
+    with nogil:
+        for ipart in range(particle_count):
+            x = particles_x1[ipart]
+            ci = hci[ipart, 0]
+            d = (x - cell_edges_x1[ci]) / (cell_edges_x1[ci + 1] - cell_edges_x1[ci])
+            w1[0] = 0.5 * (1 - d) ** 2
+            w1[1] = 0.75 - (d - 0.5) ** 2
+            w1[2] = 0.5 * d**2
 
-        x = particles_x2[ipart]
-        cj = hci[ipart, 1]
-        d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
-        w2[0] = 0.5 * (1 - d) ** 2
-        w2[1] = 0.75 - (d - 0.5) ** 2
-        w2[2] = 0.5 * d**2
+            x = particles_x2[ipart]
+            cj = hci[ipart, 1]
+            d = (x - cell_edges_x2[cj]) / (cell_edges_x2[cj + 1] - cell_edges_x2[cj])
+            w2[0] = 0.5 * (1 - d) ** 2
+            w2[1] = 0.75 - (d - 0.5) ** 2
+            w2[2] = 0.5 * d**2
 
-        x = particles_x3[ipart]
-        ck = hci[ipart, 2]
-        d = (x - cell_edges_x3[ck]) / (cell_edges_x3[ck + 1] - cell_edges_x3[ck])
-        w3[0] = 0.5 * (1 - d) ** 2
-        w3[1] = 0.75 - (d - 0.5) ** 2
-        w3[2] = 0.5 * d**2
+            x = particles_x3[ipart]
+            ck = hci[ipart, 2]
+            d = (x - cell_edges_x3[ck]) / (cell_edges_x3[ck + 1] - cell_edges_x3[ck])
+            w3[0] = 0.5 * (1 - d) ** 2
+            w3[1] = 0.75 - (d - 0.5) ** 2
+            w3[2] = 0.5 * d**2
 
-        for i in range(3):
-            for j in range(3):
-                for k in range(3):
-                    w[i][j][k] = w1[i] * w2[j] * w3[k]
+            for i in range(3):
+                for j in range(3):
+                    for k in range(3):
+                        w[i][j][k] = w1[i] * w2[j] * w3[k]
 
-        for i in range(3):
-            oci = ci - 1 + i
-            for j in range(3):
-                ocj = cj - 1 + j
-                for k in range(3):
-                    ock = ck - 1 + k
-                    if no_weight:
-                        out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart]
-                    else:
-                        out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart] * wfield_v[ipart]  # noqa E501
+            for i in range(3):
+                oci = ci - 1 + i
+                for j in range(3):
+                    ocj = cj - 1 + j
+                    for k in range(3):
+                        ock = ck - 1 + k
+                        if no_weight:
+                            out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart]
+                        else:
+                            out_v[oci, ocj, ock] += w[i][j][k] * field_v[ipart] * wfield_v[ipart]  # noqa E501


### PR DESCRIPTION
This allows multi-threading parallelism to beat single-thread walltime performances (on Python 3.12). By my measurements, it's possible to obtain better performances on multiple threads for sorted datasets and up to a couple (2 or 3) fields. I suspect this means cache misses are the main hurdle, which hinders the benefit of doing multi-threaded computations, but it's still the only option for datasets that are too large to be copied accross proceses, so I think it's worth it. 