### PR TITLE
MNT: simplify test dependency (coverage)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,7 @@ jobs:
         uv-version: 0.2.33
         uv-venv: .venv
 
-    - run: uv pip install 'coverage[toml]' --no-build
+    - run: uv pip install coverage --no-build
 
     - uses: actions/download-artifact@v4
       with:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,4 +1,4 @@
-coverage[toml]>=6.5
+coverage>=6.5
 pytest>=7.0.0
 pytest-mpl>=0.16.1
 pytest-repeat>=0.9.3


### PR DESCRIPTION
the `toml` extra is redundant on all supported Python versions (>=3.11)