### PR TITLE
ENH: add `lock` parameter to `Dataset.deposit`

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,3 +382,20 @@ Note `1` is used a placeholder "weight" for `W`, for symmetry reasons: all bound
 ```
 V(x) = (U/W)(x)
 ```
+
+
+## Thread safety
+
+Starting in gpgi 2.0.0, thread safety is guaranteed in `Dataset.host_cell_index`
+computation and `Dataset.deposit`, and both operations release the
+GIL (Global Interpreter Lock) around their respective hotloops. Thread safety is
+also tested against the experimental free-threaded build of Python 3.13.
+
+Note that, by default, `Dataset.deposit` still uses a lock per `Dataset`
+instance, which in the most general case is preferable since concurrently
+depositing many fields can cause catastrophic degradations of performances as
+it encourages cache misses. Optimal performance is however application-specific,
+so this strategy can be overridden using the `lock` parameter:
+- using `lock=None` will not use any lock, which in restricted conditions
+  leads to better walltime performances
+- alternatively, an externally managed `threading.Lock` instance may be supplied

--- a/tests/test_concurrent.py
+++ b/tests/test_concurrent.py
@@ -6,6 +6,8 @@ import threading
 from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
+import numpy.testing as npt
+import pytest
 
 import gpgi
 from gpgi._boundaries import BoundaryRegistry
@@ -29,7 +31,10 @@ def random_dataset():
             "coordinates": {
                 "x": prng.random(10_000),
                 "y": prng.random(10_000),
-            }
+            },
+            "fields": {
+                "mass": prng.random(10_000),
+            },
         },
     )
 
@@ -85,6 +90,63 @@ class TestSetupHostCellIndex:
             hci = ds._setup_host_cell_index()
             assert ds.host_cell_index is hci
             return id(hci)
+
+        with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
+            futures = [executor.submit(closure) for _ in range(N_THREADS)]
+
+        results = [f.result() for f in futures]
+        self.check(results)
+
+
+@pytest.mark.parametrize("lock", ["per-instance", None, threading.Lock()])
+class TestDeposit:
+    def check(self, results):
+        ref = results[0]
+        for res in results[1:]:
+            npt.assert_array_equal(res, ref)
+        assert len({id(res) for res in results}) == len(results)
+
+    def test_concurrent_threading(self, lock):
+        # Defines a thread barrier that will be spawned before parallel execution
+        # this increases the probability of concurrent access clashes.
+        barrier = threading.Barrier(N_THREADS)
+
+        # This object will be shared by all the threads.
+        ds = random_dataset()
+
+        results = []
+
+        def closure():
+            # Ensure that all threads reach this point before concurrent execution.
+            barrier.wait()
+            dep = ds.deposit("mass", method="nearest_grid_point", lock=lock)
+            results.append(dep)
+
+        # Spawn n threads that call _setup_host_cell_index concurrently.
+        workers = []
+        for _ in range(0, N_THREADS):
+            workers.append(threading.Thread(target=closure))
+
+        for worker in workers:
+            worker.start()
+
+        for worker in workers:
+            worker.join()
+
+        self.check(results)
+
+    def test_concurrent_pool(self, lock):
+        # Defines a thread barrier that will be spawned before parallel execution
+        # this increases the probability of concurrent access clashes.
+        barrier = threading.Barrier(N_THREADS)
+
+        # This object will be shared by all the threads.
+        ds = random_dataset()
+
+        def closure():
+            # Ensure that all threads reach this point before concurrent execution.
+            barrier.wait()
+            return ds.deposit("mass", method="nearest_grid_point", lock=lock)
 
         with ThreadPoolExecutor(max_workers=N_THREADS) as executor:
             futures = [executor.submit(closure) for _ in range(N_THREADS)]


### PR DESCRIPTION
Follow up to #245: releasing the GIL and not having any sort of lock to replace it degrades performance in the general case, so it seems preferable to have *some* locking mechanism by default (while still allowing it to be disabled, as an opt-out)

TODO:
- [x] evaluate the relative usefulness of supporting both `per-instance` and `global`, and choose a sane default if both should be conserved
- [x] doc
- [x] tests
	- [x] add tests
	- [x] check coverage. Requires #250 