### PR TITLE
MNT: auto-upgrade github actions with gha-update

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,13 +24,13 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
     - name: Build wheels for CPython
-      uses: pypa/cibuildwheel@v2.21.1
+      uses: pypa/cibuildwheel@7940a4c0e76eb2030e473a5f864f291f63ee879b # v2.21.3
       with:
         output-dir: dist
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
       with:
         name: wheels-${{ matrix.os }}
         path: dist/*.whl
@@ -40,12 +40,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
     - name: Build sdist
       run: uv build --sdist
     - name: Upload sdist
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
       with:
         name: sdist
         path: dist/*.tar.gz
@@ -65,17 +65,17 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
     steps:
     - name: Download sdist
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         name: sdist
         path: dist
 
     - name: Download wheels
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         path: dist
         pattern: wheels-*
         merge-multiple: true
 
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@f7600683efdcb7656dec5b29656edb7bc586e597 # v1.10.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
     - name: Check build
       run: |
         uvx check-manifest
@@ -68,12 +68,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout Source
-      uses: actions/checkout@v4
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
     - name: Setup Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -97,7 +97,7 @@ jobs:
       # only using reports from ubuntu because
       # combining reports from multiple platforms is tricky (or impossible ?)
       if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
       with:
         name: gpgi_coverage_data-${{matrix.os}}-${{matrix.python-version}}-${{matrix.marker}}
         path: .coverage.*
@@ -109,8 +109,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -137,14 +137,14 @@ jobs:
     # (and especially) in case of failure.
     - name: Upload pytest-mpl report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
       with:
         name: gpgi_pytest_mpl_results
         path: gpgi_pytest_mpl_results/*
 
     - name: Upload pytest-mpl baseline
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
       with:
         name: gpgi_pytest_mpl_new_baseline
         path: gpgi_pytest_mpl_new_baseline/*
@@ -155,8 +155,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -174,11 +174,11 @@ jobs:
     needs: unit-tests
 
     steps:
-    - uses: actions/checkout@v4
-    - uses: astral-sh/setup-uv@v3
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
     - run: uv python install 3.13
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
         pattern: gpgi_coverage_data-*
         merge-multiple: true
@@ -191,7 +191,7 @@ jobs:
         coverage report --fail-under=100 # >> $GITHUB_STEP_SUMMARY
 
     - name: Upload HTML report if check failed.
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@84480863f228bb9747b473957fcc9e309aa96097 # v4.4.2
       with:
         name: gpgi_coverage_report
         path: htmlcov
@@ -210,9 +210,9 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
 
-    - uses: astral-sh/setup-uv@v3
+    - uses: astral-sh/setup-uv@77c28f02b3322332d4a4446b3177f426da8bf086 # v3.1.5
       with:
         enable-cache: true
         cache-dependency-glob: |
@@ -241,14 +241,14 @@ jobs:
         - true
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
     - if: ${{ !matrix.free-threading }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - if: ${{ matrix.free-threading }}
-      uses: deadsnakes/action@v3.2.0
+      uses: deadsnakes/action@e640ac8743173a67cca4d7d77cd837e514bf98e8 # v3.2.0
       with:
         python-version: ${{ matrix.python-version }}
         nogil: true
@@ -286,7 +286,7 @@ jobs:
 
     steps:
     - name: Create issue on failure
-      uses: imjohnbo/issue-bot@v3
+      uses: imjohnbo/issue-bot@572eed14422c4d6ca37e870f97e7da209422f5bd # v3.4.4
       with:
         title: 'TST: Upcoming dependency test failures'
         body: |


### PR DESCRIPTION
As a side effect, bumps cibuuildwheel to 2.21.3, which uses Python 3.13.0 final