### PR TITLE
RFC: avoid importing enum as a namespace

### DIFF
--- a/src/gpgi/_data_types.py
+++ b/src/gpgi/_data_types.py
@@ -2,11 +2,11 @@ r"""Define the core data structures of the library: Grid, ParticleSet, and Datas
 
 from __future__ import annotations
 
-import enum
 import sys
 import warnings
 from contextlib import AbstractContextManager, nullcontext
 from copy import deepcopy
+from enum import Enum, auto
 from functools import cached_property, partial, reduce
 from textwrap import indent
 from threading import Lock
@@ -53,10 +53,10 @@ if TYPE_CHECKING:
 BoundarySpec = tuple[tuple[str, str, str], ...]
 
 
-class DepositionMethod(enum.Enum):
-    NEAREST_GRID_POINT = enum.auto()
-    CLOUD_IN_CELL = enum.auto()
-    TRIANGULAR_SHAPED_CLOUD = enum.auto()
+class DepositionMethod(Enum):
+    NEAREST_GRID_POINT = auto()
+    CLOUD_IN_CELL = auto()
+    TRIANGULAR_SHAPED_CLOUD = auto()
 
 
 _deposition_method_names: dict[str, DepositionMethod] = {

--- a/src/gpgi/_spatial_data.py
+++ b/src/gpgi/_spatial_data.py
@@ -1,6 +1,6 @@
-import enum
 import math
 from dataclasses import dataclass
+from enum import StrEnum, auto
 from itertools import chain
 from typing import Any, Protocol, TypeVar, assert_never, final
 
@@ -10,12 +10,12 @@ from numpy.typing import NDArray
 from gpgi._typing import FieldMap, Name, Real
 
 
-class Geometry(enum.StrEnum):
-    CARTESIAN = enum.auto()
-    POLAR = enum.auto()
-    CYLINDRICAL = enum.auto()
-    SPHERICAL = enum.auto()
-    EQUATORIAL = enum.auto()
+class Geometry(StrEnum):
+    CARTESIAN = auto()
+    POLAR = auto()
+    CYLINDRICAL = auto()
+    SPHERICAL = auto()
+    EQUATORIAL = auto()
 
 
 _AXES_LIMITS: dict[Name, tuple[float, float]] = {


### PR DESCRIPTION
this reduces verbosity and better aligns with the style seen in `enum`'s documentation.