### PR TITLE
TYP: refine type hints to reflect relationships between arguments and return values in terms of array dtype

### DIFF
--- a/src/gpgi/_boundaries.py
+++ b/src/gpgi/_boundaries.py
@@ -1,26 +1,25 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from threading import Lock
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import Any, Literal, cast
 
-if TYPE_CHECKING:
-    from gpgi._typing import RealArray
+from numpy.typing import NDArray
+
+from gpgi._typing import FloatT
 
 BoundaryRecipeT = Callable[
     [
-        "RealArray",
-        "RealArray",
-        "RealArray",
-        "RealArray",
-        "RealArray",
-        "RealArray",
-        "RealArray",
-        "RealArray",
+        NDArray[FloatT],
+        NDArray[FloatT],
+        NDArray[FloatT],
+        NDArray[FloatT],
+        NDArray[FloatT],
+        NDArray[FloatT],
+        NDArray[FloatT],
+        NDArray[FloatT],
         Literal["left", "right"],
         dict[str, Any],
     ],
-    "RealArray",
+    NDArray[FloatT],
 ]
 
 
@@ -126,64 +125,64 @@ class BoundaryRegistry:
 
 # basic recipes
 def open_boundary(
-    same_side_active_layer: RealArray,
-    same_side_ghost_layer: RealArray,
-    opposite_side_active_layer: RealArray,
-    opposite_side_ghost_layer: RealArray,
-    weight_same_side_active_layer: RealArray,
-    weight_same_side_ghost_layer: RealArray,
-    weight_opposite_side_active_layer: RealArray,
-    weight_opposite_side_ghost_layer: RealArray,
+    same_side_active_layer: NDArray[FloatT],
+    same_side_ghost_layer: NDArray[FloatT],
+    opposite_side_active_layer: NDArray[FloatT],
+    opposite_side_ghost_layer: NDArray[FloatT],
+    weight_same_side_active_layer: NDArray[FloatT],
+    weight_same_side_ghost_layer: NDArray[FloatT],
+    weight_opposite_side_active_layer: NDArray[FloatT],
+    weight_opposite_side_ghost_layer: NDArray[FloatT],
     side: Literal["left", "right"],
     metadata: dict[str, Any],
-) -> RealArray:
+) -> NDArray[FloatT]:
     # return the active layer unchanged
     return same_side_active_layer
 
 
 def wall_boundary(
-    same_side_active_layer: RealArray,
-    same_side_ghost_layer: RealArray,
-    opposite_side_active_layer: RealArray,
-    opposite_side_ghost_layer: RealArray,
-    weight_same_side_active_layer: RealArray,
-    weight_same_side_ghost_layer: RealArray,
-    weight_opposite_side_active_layer: RealArray,
-    weight_opposite_side_ghost_layer: RealArray,
+    same_side_active_layer: NDArray[FloatT],
+    same_side_ghost_layer: NDArray[FloatT],
+    opposite_side_active_layer: NDArray[FloatT],
+    opposite_side_ghost_layer: NDArray[FloatT],
+    weight_same_side_active_layer: NDArray[FloatT],
+    weight_same_side_ghost_layer: NDArray[FloatT],
+    weight_opposite_side_active_layer: NDArray[FloatT],
+    weight_opposite_side_ghost_layer: NDArray[FloatT],
     side: Literal["left", "right"],
     metadata: dict[str, Any],
-) -> RealArray:
-    return cast("RealArray", same_side_active_layer + same_side_ghost_layer)
+) -> NDArray[FloatT]:
+    return cast(NDArray[FloatT], same_side_active_layer + same_side_ghost_layer)
 
 
 def antisymmetric_boundary(
-    same_side_active_layer: RealArray,
-    same_side_ghost_layer: RealArray,
-    opposite_side_active_layer: RealArray,
-    opposite_side_ghost_layer: RealArray,
-    weight_same_side_active_layer: RealArray,
-    weight_same_side_ghost_layer: RealArray,
-    weight_opposite_side_active_layer: RealArray,
-    weight_opposite_side_ghost_layer: RealArray,
+    same_side_active_layer: NDArray[FloatT],
+    same_side_ghost_layer: NDArray[FloatT],
+    opposite_side_active_layer: NDArray[FloatT],
+    opposite_side_ghost_layer: NDArray[FloatT],
+    weight_same_side_active_layer: NDArray[FloatT],
+    weight_same_side_ghost_layer: NDArray[FloatT],
+    weight_opposite_side_active_layer: NDArray[FloatT],
+    weight_opposite_side_ghost_layer: NDArray[FloatT],
     side: Literal["left", "right"],
     metadata: dict[str, Any],
-) -> RealArray:
-    return cast("RealArray", same_side_active_layer - same_side_ghost_layer)
+) -> NDArray[FloatT]:
+    return cast(NDArray[FloatT], same_side_active_layer - same_side_ghost_layer)
 
 
 def periodic_boundary(
-    same_side_active_layer: RealArray,
-    same_side_ghost_layer: RealArray,
-    opposite_side_active_layer: RealArray,
-    opposite_side_ghost_layer: RealArray,
-    weight_same_side_active_layer: RealArray,
-    weight_same_side_ghost_layer: RealArray,
-    weight_opposite_side_active_layer: RealArray,
-    weight_opposite_side_ghost_layer: RealArray,
+    same_side_active_layer: NDArray[FloatT],
+    same_side_ghost_layer: NDArray[FloatT],
+    opposite_side_active_layer: NDArray[FloatT],
+    opposite_side_ghost_layer: NDArray[FloatT],
+    weight_same_side_active_layer: NDArray[FloatT],
+    weight_same_side_ghost_layer: NDArray[FloatT],
+    weight_opposite_side_active_layer: NDArray[FloatT],
+    weight_opposite_side_ghost_layer: NDArray[FloatT],
     side: Literal["left", "right"],
     metadata: dict[str, Any],
-) -> RealArray:
-    return cast("RealArray", same_side_active_layer + opposite_side_ghost_layer)
+) -> NDArray[FloatT]:
+    return cast(NDArray[FloatT], same_side_active_layer + opposite_side_ghost_layer)
 
 
 _base_registry: dict[str, BoundaryRecipeT] = {

--- a/src/gpgi/_load.py
+++ b/src/gpgi/_load.py
@@ -8,16 +8,16 @@ from gpgi._typing import FieldMap
 if TYPE_CHECKING:
     from typing import Any, Literal
 
-    from gpgi._typing import GridDict, ParticleSetDict
+    from gpgi._typing import FloatT, GridDict, ParticleSetDict
 
 
 def load(
     *,
     geometry: Literal["cartesian", "polar", "cylindrical", "spherical", "equatorial"],
-    grid: GridDict,
-    particles: ParticleSetDict | None = None,
+    grid: GridDict[FloatT],
+    particles: ParticleSetDict[FloatT] | None = None,
     metadata: dict[str, Any] | None = None,
-) -> Dataset:
+) -> Dataset[FloatT]:
     r"""
     Load a Dataset.
 

--- a/src/gpgi/_spatial_data.py
+++ b/src/gpgi/_spatial_data.py
@@ -7,7 +7,7 @@ from typing import Any, Protocol, TypeVar, assert_never, final
 import numpy as np
 from numpy.typing import NDArray
 
-from gpgi._typing import FieldMap, Name, Real
+from gpgi._typing import FieldMap, FloatT, Name
 
 
 class Geometry(StrEnum):
@@ -154,7 +154,7 @@ class FieldMapsValidatorHelper:
     @staticmethod
     def _validate_shape_equality(
         name: str,
-        data: NDArray[Real],
+        data: NDArray[FloatT],
         ref_arr: NamedArray | None,
     ) -> NamedArray:
         if ref_arr is not None and data.shape != ref_arr.data.shape:
@@ -165,7 +165,7 @@ class FieldMapsValidatorHelper:
         return ref_arr or NamedArray(name, data)
 
     @staticmethod
-    def _validate_sorted_state(name: str, data: NDArray[Real]) -> None:
+    def _validate_sorted_state(name: str, data: NDArray[FloatT]) -> None:
         a = data[0]
         for i, b in enumerate(data[1:], start=1):
             if a > b:
@@ -178,7 +178,7 @@ class FieldMapsValidatorHelper:
     @staticmethod
     def _validate_required_attributes(
         name: str,
-        data: NDArray[Real],
+        data: NDArray[FloatT],
         required_attrs: dict[str, Any],
     ) -> None:
         for attr, expected in required_attrs.items():

--- a/src/gpgi/_typing.py
+++ b/src/gpgi/_typing.py
@@ -1,61 +1,60 @@
-from typing import NotRequired, TypedDict, TypeVar
+from typing import Generic, NotRequired, TypedDict, TypeVar
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 
-Real = TypeVar("Real", np.float32, np.float64)
-RealArray = npt.NDArray[Real]
-HCIArray = npt.NDArray[np.uint16]
+FloatT = TypeVar("FloatT", np.float32, np.float64)
+HCIArray = NDArray[np.uint16]
 
 
 Name = str
-FieldMap = dict[str, np.ndarray]
+FieldMap = dict[str, NDArray[FloatT]]
 
 
-class CartesianCoordinates(TypedDict):
-    x: np.ndarray
-    y: NotRequired[np.ndarray]
-    z: NotRequired[np.ndarray]
+class CartesianCoordinates(TypedDict, Generic[FloatT]):
+    x: NDArray[FloatT]
+    y: NotRequired[NDArray[FloatT]]
+    z: NotRequired[NDArray[FloatT]]
 
 
-class CylindricalCoordinates(TypedDict):
-    radius: np.ndarray
-    azimuth: NotRequired[np.ndarray]
-    z: NotRequired[np.ndarray]
+class CylindricalCoordinates(TypedDict, Generic[FloatT]):
+    radius: NDArray[FloatT]
+    azimuth: NotRequired[NDArray[FloatT]]
+    z: NotRequired[NDArray[FloatT]]
 
 
-class PolarCoordinates(TypedDict):
-    radius: np.ndarray
-    z: NotRequired[np.ndarray]
-    azimuth: NotRequired[np.ndarray]
+class PolarCoordinates(TypedDict, Generic[FloatT]):
+    radius: NDArray[FloatT]
+    z: NotRequired[NDArray[FloatT]]
+    azimuth: NotRequired[NDArray[FloatT]]
 
 
-class SphericalCoordinates(TypedDict):
-    colatitude: np.ndarray
-    radius: NotRequired[np.ndarray]
-    azimuth: NotRequired[np.ndarray]
+class SphericalCoordinates(TypedDict, Generic[FloatT]):
+    colatitude: NDArray[FloatT]
+    radius: NotRequired[NDArray[FloatT]]
+    azimuth: NotRequired[NDArray[FloatT]]
 
 
-class EquatorialCoordinates(TypedDict):
-    radius: np.ndarray
-    latitude: NotRequired[np.ndarray]
-    azimuth: NotRequired[np.ndarray]
+class EquatorialCoordinates(TypedDict, Generic[FloatT]):
+    radius: NDArray[FloatT]
+    latitude: NotRequired[NDArray[FloatT]]
+    azimuth: NotRequired[NDArray[FloatT]]
 
 
 CoordMap = (
-    CartesianCoordinates
-    | CylindricalCoordinates
-    | PolarCoordinates
-    | SphericalCoordinates
-    | EquatorialCoordinates
+    CartesianCoordinates[FloatT]
+    | CylindricalCoordinates[FloatT]
+    | PolarCoordinates[FloatT]
+    | SphericalCoordinates[FloatT]
+    | EquatorialCoordinates[FloatT]
 )
 
 
-class GridDict(TypedDict):
-    cell_edges: CoordMap
-    fields: NotRequired[FieldMap]
+class GridDict(TypedDict, Generic[FloatT]):
+    cell_edges: CoordMap[FloatT]
+    fields: NotRequired[FieldMap[FloatT]]
 
 
-class ParticleSetDict(TypedDict):
-    coordinates: CoordMap
-    fields: NotRequired[FieldMap]
+class ParticleSetDict(TypedDict, Generic[FloatT]):
+    coordinates: CoordMap[FloatT]
+    fields: NotRequired[FieldMap[FloatT]]

--- a/src/gpgi/typing.py
+++ b/src/gpgi/typing.py
@@ -8,7 +8,9 @@ from typing import TYPE_CHECKING, Any, Protocol
 from gpgi._typing import FieldMap
 
 if TYPE_CHECKING:
-    from gpgi._typing import HCIArray, RealArray
+    from numpy.typing import NDArray
+
+    from gpgi._typing import FloatT, HCIArray
 
 
 __all__ = [
@@ -21,32 +23,32 @@ __all__ = [
 class DepositionMethodT(Protocol):
     def __call__(  # noqa D102
         self,
-        cell_edges_x1: RealArray,
-        cell_edges_x2: RealArray,
-        cell_edges_x3: RealArray,
-        particles_x1: RealArray,
-        particles_x2: RealArray,
-        particles_x3: RealArray,
-        field: RealArray,
-        weight_field: RealArray,
+        cell_edges_x1: NDArray[FloatT],
+        cell_edges_x2: NDArray[FloatT],
+        cell_edges_x3: NDArray[FloatT],
+        particles_x1: NDArray[FloatT],
+        particles_x2: NDArray[FloatT],
+        particles_x3: NDArray[FloatT],
+        field: NDArray[FloatT],
+        weight_field: NDArray[FloatT],
         hci: HCIArray,
-        out: RealArray,
+        out: NDArray[FloatT],
     ) -> None: ...
 
 
 class DepositionMethodWithMetadataT(Protocol):
     def __call__(  # noqa D102
         self,
-        cell_edges_x1: RealArray,
-        cell_edges_x2: RealArray,
-        cell_edges_x3: RealArray,
-        particles_x1: RealArray,
-        particles_x2: RealArray,
-        particles_x3: RealArray,
-        field: RealArray,
-        weight_field: RealArray,
+        cell_edges_x1: NDArray[FloatT],
+        cell_edges_x2: NDArray[FloatT],
+        cell_edges_x3: NDArray[FloatT],
+        particles_x1: NDArray[FloatT],
+        particles_x2: NDArray[FloatT],
+        particles_x3: NDArray[FloatT],
+        field: NDArray[FloatT],
+        weight_field: NDArray[FloatT],
         hci: HCIArray,
-        out: RealArray,
+        out: NDArray[FloatT],
         *,
         metadata: dict[str, Any],
     ) -> None: ...


### PR DESCRIPTION
This replaces #290: it's essentially the same PR, but the scope evolved while stabilizing it.

close #290