### PR TITLE
TST: bump ubuntu image in minimal requirements jobs (20.04 -> 22.04)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
 
   minimal-env:
     name: Minimal requirements
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
     - uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
context: https://github.com/actions/runner-images/issues/11101
