### PR TITLE
ENH: report as many exceptions as possible from `gpgi.load` instead of just the first one encountered

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ Changelog = "https://github.com/neutrinoceros/gpgi/blob/main/CHANGELOG.md"
 test = [
     "matplotlib>=3.6.0",
     "pytest-mpl>=0.16.1",
-    "pytest>=7.0.0",
+    "pytest>=8.0.0",
 ]
 covcheck = [
     {include-group = "test"},
@@ -156,6 +156,7 @@ follow_imports = "silent"
 filterwarnings = [
   "error",
   'ignore:Matplotlib is currently using agg, which is a non-GUI backend:UserWarning',
+  'ignore:in 3.12 __contains__ will no longer raise TypeError:DeprecationWarning',
 ]
 addopts = "-ra"
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -73,6 +73,22 @@ def test_load_empty_particles():
         )
 
 
+def test_load_empty_grid_and_empty_particles():
+    with pytest.raises(
+        ExceptionGroup,
+        match=r"^Invalid inputs were received \(2 sub-exceptions\)",
+    ) as excinfo:
+        gpgi.load(geometry="cartesian", grid={}, particles={})
+
+    assert excinfo.group_contains(
+        ValueError, match="grid dictionary missing required key 'cell_edges'"
+    )
+    assert excinfo.group_contains(
+        ValueError, match="particles dictionary missing required key 'coordinates'"
+    )
+    assert len(excinfo.value.exceptions) == 2
+
+
 def test_unsorted_cell_edges():
     with pytest.raises(
         ValueError,

--- a/uv.lock
+++ b/uv.lock
@@ -233,14 +233,14 @@ requires-dist = [{ name = "numpy", specifier = ">=1.25,<3" }]
 [package.metadata.requires-dev]
 concurrency = [
     { name = "matplotlib", specifier = ">=3.6.0" },
-    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-mpl", specifier = ">=0.16.1" },
     { name = "pytest-repeat", specifier = ">=0.9.3" },
 ]
 covcheck = [
     { name = "coverage", specifier = ">=7.6.1" },
     { name = "matplotlib", specifier = ">=3.6.0" },
-    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-mpl", specifier = ">=0.16.1" },
 ]
 dev = [
@@ -251,7 +251,7 @@ dev = [
 ]
 test = [
     { name = "matplotlib", specifier = ">=3.6.0" },
-    { name = "pytest", specifier = ">=7.0.0" },
+    { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-mpl", specifier = ">=0.16.1" },
 ]
 typecheck = [


### PR DESCRIPTION
Partially addresses #338