### PR TITLE
TYP: auto-fix TC006 violations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ source = [
 omit = [
     "src/gpgi/_backports.py",
     "src/gpgi/_typing.py",
+    "src/gpgi/typing.py",
 ]
 
 [tool.coverage.report]

--- a/src/gpgi/_boundaries.py
+++ b/src/gpgi/_boundaries.py
@@ -152,7 +152,7 @@ def wall_boundary(
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> NDArray[FloatT]:
-    return cast(NDArray[FloatT], same_side_active_layer + same_side_ghost_layer)
+    return cast("NDArray[FloatT]", same_side_active_layer + same_side_ghost_layer)
 
 
 def antisymmetric_boundary(
@@ -167,7 +167,7 @@ def antisymmetric_boundary(
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> NDArray[FloatT]:
-    return cast(NDArray[FloatT], same_side_active_layer - same_side_ghost_layer)
+    return cast("NDArray[FloatT]", same_side_active_layer - same_side_ghost_layer)
 
 
 def periodic_boundary(
@@ -182,7 +182,7 @@ def periodic_boundary(
     side: Literal["left", "right"],
     metadata: dict[str, Any],
 ) -> NDArray[FloatT]:
-    return cast(NDArray[FloatT], same_side_active_layer + opposite_side_ghost_layer)
+    return cast("NDArray[FloatT]", same_side_active_layer + opposite_side_ghost_layer)
 
 
 _base_registry: dict[str, BoundaryRecipeT] = {

--- a/src/gpgi/_data_types.py
+++ b/src/gpgi/_data_types.py
@@ -37,7 +37,6 @@ from gpgi._spatial_data import (
     Validator,
 )
 from gpgi._typing import FieldMap, FloatT, Name
-from gpgi.typing import DepositionMethodT, DepositionMethodWithMetadataT
 
 if sys.version_info >= (3, 13):
     LockType = Lock
@@ -49,7 +48,8 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    from gpgi._typing import FieldMap, HCIArray, Name
+    from gpgi._typing import HCIArray
+    from gpgi.typing import DepositionMethodT, DepositionMethodWithMetadataT
 
 
 BoundarySpec = tuple[tuple[str, str, str], ...]
@@ -644,10 +644,10 @@ class Dataset(Generic[FloatT]):
             sig = signature(method)
             func: DepositionMethodT
             if "metadata" in sig.parameters:
-                method = cast(DepositionMethodWithMetadataT, method)
+                method = cast("DepositionMethodWithMetadataT", method)
                 func = partial(method, metadata=self.metadata)
             else:
-                method = cast(DepositionMethodT, method)
+                method = cast("DepositionMethodT", method)
                 func = method
         else:
             if method not in _deposition_method_names:
@@ -808,7 +808,7 @@ class Dataset(Generic[FloatT]):
             iax = axes.index(ax)
             bcs = tuple(self.boundary_recipes[key] for key in bv)
             for side, bc in zip(("left", "right"), bcs, strict=True):
-                side = cast(Literal["left", "right"], side)
+                side = cast("Literal['left', 'right']", side)
                 active_index: int = 1 if side == "left" else -2
                 same_side_active_layer_idx = [slice(None)] * self.grid.ndim
                 same_side_active_layer_idx[iax] = active_index  # type:ignore [call-overload]

--- a/src/gpgi/_load.py
+++ b/src/gpgi/_load.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, cast
 
 from gpgi._data_types import Dataset, Geometry, Grid, ParticleSet
-from gpgi._typing import FieldMap
 
 if TYPE_CHECKING:
     from typing import Any, Literal
 
-    from gpgi._typing import FloatT, GridDict, ParticleSetDict
+    from gpgi._typing import FieldMap, FloatT, GridDict, ParticleSetDict
 
 
 def load(
@@ -70,7 +69,7 @@ def load(
 
     _grid = Grid(
         geometry=_geometry,
-        cell_edges=cast(FieldMap, grid["cell_edges"]),
+        cell_edges=cast("FieldMap", grid["cell_edges"]),
         fields=grid.get("fields"),
     )
 
@@ -78,7 +77,7 @@ def load(
     if particles is not None:
         _particles = ParticleSet(
             geometry=_geometry,
-            coordinates=cast(FieldMap, particles["coordinates"]),
+            coordinates=cast("FieldMap", particles["coordinates"]),
             fields=particles.get("fields"),
         )
 


### PR DESCRIPTION
These refactors were automated with ruff 0.10.0, including `--unsafe-fixes`.