### PR TITLE
WHL: don’t skip tests on musllinux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ test-command = [
     "python -m pytest --color=yes tests",
     "python -m pytest --color=yes --count 500 tests/test_concurrent.py",
 ]
-test-skip = "*-musllinux*"
 
 [tool.cibuildwheel.linux]
 archs = "x86_64"


### PR DESCRIPTION
No reason to skip these now that numpy has wheels for this platform 