### PR TITLE
WHL: partially delegate arch selection to cibuildwheel (use `archs='auto'`)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,13 +179,13 @@ test-command = [
 ]
 
 [tool.cibuildwheel.linux]
-archs = "x86_64"
+archs = "auto"
 
 [tool.cibuildwheel.macos]
-archs = "auto64"
+archs = "auto"
 
 [tool.cibuildwheel.windows]
-archs = "AMD64"
+archs = "auto"
 
 [[tool.cibuildwheel.overrides]]
 # Install numpy from nightly wheels as not yet on PyPI.


### PR DESCRIPTION
In effect this adds win32 wheels as of cibuildwheel 3.0.0
ref: https://cibuildwheel.pypa.io/en/stable/options/#archs