### PR TITLE
WHL: stop shipping wheels for macOS x86_64 (mac-intel)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,7 @@ jobs:
         - ubuntu-latest
         - ubuntu-24.04-arm
         - windows-latest
-        - macos-13 # x86_64
-        - macos-latest # arm64
+        - macos-latest
       fail-fast: false
 
     steps:


### PR DESCRIPTION
To be merged when the `macos-13` image is discontinued, sometimes between Sept 1st and Nov 15th