### PR TITLE
BLD/WHL: skip setting up uv on Linux builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -51,7 +51,8 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
+    - if: ${{ !startswith( matrix.os , 'ubuntu' ) }}
+      uses: astral-sh/setup-uv@e92bafb6253dcd438e0484186d7669ea7a8ca1cc # v6.4.3
       with:
         enable-cache: true
         prune-cache: false


### PR DESCRIPTION
I *think* this step isn't necessary, at least on Linux, where I know that uv is included in docker images used through cibuildwheel. Let's see if this works. 