### PR TITLE
WHL: drop win32 support (stop distributing wheels)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,10 +48,6 @@ jobs:
           archs: AMD64
           select: '*'
           id: windows_AMD64
-        - os: windows-latest
-          archs: x86
-          select: '*'
-          id: windows_x86
         - os: windows-11-arm
           archs: ARM64
           select: '*'
@@ -62,11 +58,6 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
-    - name: Setup MSVC (windows 32-bit)
-      if: ${{ startsWith(runner.os, 'windows') && matrix.archs == 'x86' }}
-      uses: bus1/cabuild/action/msdevshell@e22aba57d6e74891d059d66501b6b5aed8123c4d  # v1
-      with:
-        architecture: x86
     - name: Build wheels for CPython
       uses: pypa/cibuildwheel@ee02a1537ce3071a004a6b08c41e72f0fdc42d9a # v3.4.0
       env:


### PR DESCRIPTION
following numpy dropping this target
partially reverts #384
no changelog entry needed: no wheels were released for this target ever